### PR TITLE
Moving ReadOnlyCollection to a different namespace

### DIFF
--- a/Octokit/Net40List.cs
+++ b/Octokit/Net40List.cs
@@ -265,9 +265,9 @@ namespace System.Collections.Generic
             InsertRange(_size, collection);
         }
 
-        public ReadOnlyCollection<T> AsReadOnly()
+        public Octokit.ReadOnlyCollection<T> AsReadOnly()
         {
-            return new ReadOnlyCollection<T>(this);
+            return new Octokit.ReadOnlyCollection<T>(this);
         }
 
         // Searches a section of the list for a given element using a binary search

--- a/Octokit/ReadOnlyCollection.cs
+++ b/Octokit/ReadOnlyCollection.cs
@@ -1,4 +1,4 @@
-﻿namespace System.Collections.Generic
+﻿namespace Octokit
 {
     using System;
     using System.Collections;

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -3,12 +3,12 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyProductAttribute("Octokit")]
-[assembly: AssemblyVersionAttribute("0.23.0")]
-[assembly: AssemblyFileVersionAttribute("0.23.0")]
+[assembly: AssemblyVersionAttribute("0.23.0.1")]
+[assembly: AssemblyFileVersionAttribute("0.23.0.1")]
 [assembly: ComVisibleAttribute(false)]
 namespace System {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "0.23.0";
-        internal const string InformationalVersion = "0.23.0";
+        internal const string Version = "0.23.0.1-ghu";
+        internal const string InformationalVersion = "0.23.0.1-ghu";
     }
 }


### PR DESCRIPTION
Fixing the namespace so that it doesn't collide with the existing type in .net 3.5, which is in another System namespace.

This fixes https://github.com/github-for-unity/Unity/issues/64 and is included as a binary build there.