### PR TITLE
Updating Octokit to the 0.24.0

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at [support@github.com](mailto:support@github.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
@@ -47,6 +47,26 @@ namespace Octokit.Reactive
         IObservable<bool> CheckAssignee(string owner, string name, string assignee);
 
         /// <summary>
+        /// Add assignees to a specified Issue.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="assignees">List of names of assignees to add</param>
+        /// <returns></returns>
+        IObservable<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees);
+
+        /// <summary>
+        /// Remove assignees from a specified Issue.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="assignees">List of assignees to remove </param>
+        /// <returns></returns>
+        IObservable<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees);
+
+        /// <summary>
         /// Checks to see if a user is an assignee for a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
@@ -40,7 +40,7 @@ namespace Octokit.Reactive
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
-        
+
         /// <summary>
         /// List reactions for a specified Commit Comment
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
@@ -19,7 +19,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         IObservable<CommitStatus> GetAll(string owner, string name, string reference);
-        
+
         /// <summary>
         /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.

--- a/Octokit.Reactive/Clients/IObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitsClient.cs
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
         IObservable<Commit> Create(string owner, string name, NewCommit commit);
-        
+
         /// <summary>
         /// Create a commit for a given repository
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableDeploymentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         IObservable<Deployment> GetAll(string owner, string name);
-        
+
         /// <summary>
         /// Gets all the deployments for the specified repository. Any user with pull access
         /// to a repository can view deployments.
@@ -43,7 +43,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         IObservable<Deployment> GetAll(string owner, string name, ApiOptions options);
-        
+
         /// <summary>
         /// Gets all the deployments for the specified repository. Any user with pull access
         /// to a repository can view deployments.

--- a/Octokit.Reactive/Clients/IObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableEventsClient.cs
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        IObservable<Activity> GetAllIssuesForRepository(string owner, string name);
+        IObservable<IssueEvent> GetAllIssuesForRepository(string owner, string name);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -85,7 +85,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Activity> GetAllIssuesForRepository(long repositoryId);
+        IObservable<IssueEvent> GetAllIssuesForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Activity> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
+        IObservable<IssueEvent> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -106,7 +106,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Activity> GetAllIssuesForRepository(long repositoryId, ApiOptions options);
+        IObservable<IssueEvent> GetAllIssuesForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the events for a given repository network

--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -66,6 +66,42 @@ namespace Octokit.Reactive
         IObservable<IssueComment> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        IObservable<IssueComment> GetAllForRepository(string owner, string name, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        IObservable<IssueComment> GetAllForRepository(long repositoryId, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<IssueComment> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<IssueComment> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>

--- a/Octokit.Reactive/Clients/IObservableIssueTimelineClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueTimelineClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int number, ApiOptions options);
-        
+
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number);
-        
+
         /// <summary>
         /// Gets all events for the issue.
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
@@ -22,7 +22,7 @@ namespace Octokit.Reactive
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         IObservable<Milestone> Get(string owner, string name, int number);
-        
+
         /// <summary>
         /// Gets a single Milestone by number.
         /// </summary>
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
         IObservable<Milestone> GetAllForRepository(string owner, string name);
-        
+
         /// <summary>
         /// Gets all open milestones for the repository.
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
@@ -46,6 +46,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [Obsolete("Please use IObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
         IObservable<Organization> GetAll(string user);
 
         /// <summary>
@@ -54,7 +55,36 @@ namespace Octokit.Reactive
         /// <param name="user">The login for the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [Obsolete("Please use IObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]  
         IObservable<Organization> GetAll(string user, ApiOptions options);
+
+        /// <summary>
+        /// Returns all the organizations for the specified user
+        /// </summary>
+        /// <param name="user">The login for the user</param>
+        /// <returns></returns>
+        IObservable<Organization> GetAllForUser(string user);
+
+        /// <summary>
+        /// Returns all the organizations for the specified user
+        /// </summary>
+        /// <param name="user">The login for the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Organization> GetAllForUser(string user, ApiOptions options);
+
+        /// <summary>
+        /// Returns all the organizations
+        /// </summary>
+        /// <returns></returns>
+        IObservable<Organization> GetAll();
+
+        /// <summary>
+        /// Returns all the organizations
+        /// </summary>
+        /// <param name="request">Search parameters of the last organization seen</param>
+        /// <returns></returns>
+        IObservable<Organization> GetAll(OrganizationRequest request);
 
         /// <summary>
         /// Update the specified organization with data from <see cref="OrganizationUpdate"/>.

--- a/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// <param name="user">The login for the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        [Obsolete("Please use IObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]  
+        [Obsolete("Please use IObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
         IObservable<Organization> GetAll(string user, ApiOptions options);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -12,9 +12,15 @@ namespace Octokit.Reactive
     public interface IObservablePullRequestsClient
     {
         /// <summary>
-        /// Client for managing comments.
+        /// Client for managing review comments.
         /// </summary>
+        [Obsolete("Please use IObservablePullRequestsClient.ReviewComment. This will be removed in a future version")]
         IObservablePullRequestReviewCommentsClient Comment { get; }
+
+        /// <summary>
+        /// Client for managing review comments.
+        /// </summary>
+        IObservablePullRequestReviewCommentsClient ReviewComment { get; }
 
         /// <summary>
         /// Gets a single Pull Request by number.

--- a/Octokit.Reactive/Clients/IObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReferencesClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<Reference> Get(string owner, string name, string reference);
-        
+
         /// <summary>
         /// Gets a reference for a given repository by reference name
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -231,7 +231,7 @@ namespace Octokit.Reactive
         /// <param name="data">Description of the asset with its data</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         IObservable<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data);
-        
+
         /// <summary>
         /// Gets the specified <see cref="ReleaseAsset"/> for the specified release of the specified repository.
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -36,7 +36,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         IObservable<string> GetReadmeHtml(long repositoryId);
-        
+
         /// <summary>
         /// Get an archive of a given repository's contents
         /// </summary>
@@ -167,7 +167,7 @@ namespace Octokit.Reactive
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <param name="path">The content path</param>
         IObservable<RepositoryContent> GetAllContentsByRef(long repositoryId, string reference, string path);
-        
+
         /// <summary>
         /// Returns the contents of the home directory in a repository.
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         IObservable<RepositoryHook> GetAll(string owner, string name, ApiOptions options);
-        
+
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStarredClient.cs
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
         IObservable<User> GetAllStargazers(string owner, string name, ApiOptions options);
-        
+
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository
         /// </summary>
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         IObservable<UserStar> GetAllStargazersWithTimestamps(string owner, string name);
-        
+
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
         /// </summary>
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
         IObservable<Repository> GetAllForCurrent();
-        
+
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user
         /// </summary>
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         IObservable<RepositoryStar> GetAllForCurrentWithTimestamps();
-        
+
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user with star creation timestamps.
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
@@ -88,6 +88,39 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Add assignees to a specified Issue.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="assignees">List of names of assignees to add</param>
+        public IObservable<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(assignees, "assignees");
+
+            return _client.AddAssignees(owner, name, number, assignees).ToObservable();
+        }
+
+        /// <summary>
+        /// Remove assignees from a specified Issue.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="assignees">List of assignees to remove </param>
+        /// <returns></returns>
+        public IObservable<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(assignees, "assignees");
+
+            return _client.RemoveAssignees(owner, name, number, assignees).ToObservable();
+        }
+
+        /// <summary>
         /// Checks to see if a user is an assignee for a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -37,7 +37,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return GetAll(owner, name ,reference, ApiOptions.None);
+            return GetAll(owner, name, reference, ApiOptions.None);
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
-            Ensure.ArgumentNotNull(options, "options"); 
+            Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference), options);
         }

--- a/Octokit.Reactive/Clients/ObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableEventsClient.cs
@@ -107,14 +107,14 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets all the events for a given repository
+        /// Gets all the issue events for a given repository
         /// </summary>
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        public IObservable<Activity> GetAllIssuesForRepository(string owner, string name)
+        public IObservable<IssueEvent> GetAllIssuesForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -129,13 +129,13 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Activity> GetAllIssuesForRepository(long repositoryId)
+        public IObservable<IssueEvent> GetAllIssuesForRepository(long repositoryId)
         {
             return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
         }
 
         /// <summary>
-        /// Gets all the events for a given repository
+        /// Gets all the issue events for a given repository
         /// </summary>
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
@@ -143,13 +143,13 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Activity> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
+        public IObservable<IssueEvent> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.IssuesEvents(owner, name), options);
+            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(owner, name), options);
         }
 
         /// <summary>
@@ -160,11 +160,11 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Activity> GetAllIssuesForRepository(long repositoryId, ApiOptions options)
+        public IObservable<IssueEvent> GetAllIssuesForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.IssuesEvents(repositoryId), options);
+            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(repositoryId), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableEventsClient.cs
@@ -382,7 +382,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.OrganizationEvents(user, organization),options);            
+            return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.OrganizationEvents(user, organization), options);
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableGistCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistCommentsClient.cs
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// <returns>IObservable{GistComment}.</returns>
         public IObservable<GistComment> GetAllForGist(string gistId)
         {
-            Ensure.ArgumentNotNullOrEmptyString(gistId, "gistId");             
+            Ensure.ArgumentNotNullOrEmptyString(gistId, "gistId");
 
             return GetAllForGist(gistId, ApiOptions.None);
         }

--- a/Octokit.Reactive/Clients/ObservableGistsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistsClient.cs
@@ -111,7 +111,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public IObservable<Gist> GetAll(DateTimeOffset since)
-        {            
+        {
             return GetAll(since, ApiOptions.None);
         }
 
@@ -179,7 +179,7 @@ namespace Octokit.Reactive
         /// <param name="options">Options for changing the API response</param>
         public IObservable<Gist> GetAllPublic(DateTimeOffset since, ApiOptions options)
         {
-            Ensure.ArgumentNotNull(options, "options"); 
+            Ensure.ArgumentNotNull(options, "options");
 
             var request = new GistRequest(since);
             return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.PublicGists(), request.ToParametersDictionary(), options);

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -87,7 +87,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForRepository(owner, name, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -100,7 +100,69 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(repositoryId), options);
+            return GetAllForRepository(repositoryId, new IssueCommentRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public IObservable<IssueComment> GetAllForRepository(string owner, string name, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public IObservable<IssueComment> GetAllForRepository(long repositoryId, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<IssueComment> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<IssueComment> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(repositoryId), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.Organizations());
+            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations());
         }
 
         /// <summary>
@@ -72,11 +72,12 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [Obsolete("Please use ObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
         public IObservable<Organization> GetAll(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
-            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.Organizations(user));
+            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user));
         }
 
         /// <summary>
@@ -85,12 +86,62 @@ namespace Octokit.Reactive
         /// <param name="user">The login for the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [Obsolete("Please use ObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
         public IObservable<Organization> GetAll(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.Organizations(user), options);
+            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user), options);
+        }
+
+        /// <summary>
+        /// Returns all the organizations for the specified user
+        /// </summary>
+        /// <param name="user">The login for the user</param>
+        /// <returns></returns>
+        public IObservable<Organization> GetAllForUser(string user)
+        {
+          Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
+          return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user));
+        }
+
+        /// <summary>
+        /// Returns all the organizations for the specified user
+        /// </summary>
+        /// <param name="user">The login for the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Organization> GetAllForUser(string user, ApiOptions options)
+        {
+          Ensure.ArgumentNotNullOrEmptyString(user, "user");
+          Ensure.ArgumentNotNull(options, "options");
+
+          return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user), options);
+        }
+
+        /// <summary>
+        /// Returns all the organizations
+        /// </summary>
+        /// <returns></returns>
+        public IObservable<Organization> GetAll()
+        {
+            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.AllOrganizations());
+        }
+
+        /// <summary>
+        /// Returns all the organizations
+        /// </summary>
+        /// <param name="request">Search parameters of the last organization seen</param>
+        /// <returns></returns>
+        public IObservable<Organization> GetAll(OrganizationRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            var url = ApiUrls.AllOrganizations(request.Since);
+
+            return _connection.GetAndFlattenAllPages<Organization>(url);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
@@ -102,9 +102,9 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Organization> GetAllForUser(string user)
         {
-          Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
-          return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user));
+            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user));
         }
 
         /// <summary>
@@ -115,10 +115,10 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Organization> GetAllForUser(string user, ApiOptions options)
         {
-          Ensure.ArgumentNotNullOrEmptyString(user, "user");
-          Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            Ensure.ArgumentNotNull(options, "options");
 
-          return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user), options);
+            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(client, "client");
 
-            _client = client.PullRequest.Comment;
+            _client = client.PullRequest.ReviewComment;
             _connection = client.Connection;
         }
 

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -16,9 +16,15 @@ namespace Octokit.Reactive
         readonly IConnection _connection;
 
         /// <summary>
-        /// Client for managing comments.
+        /// Client for managing review comments.
         /// </summary>
-        public IObservablePullRequestReviewCommentsClient Comment { get; private set; }
+        [Obsolete("Please use ObservablePullRequestsClient.ReviewComment. This will be removed in a future version")]
+        public IObservablePullRequestReviewCommentsClient Comment { get { return this.ReviewComment; } }
+
+        /// <summary>
+        /// Client for managing review comments.
+        /// </summary>
+        public IObservablePullRequestReviewCommentsClient ReviewComment { get; private set; }
 
         public ObservablePullRequestsClient(IGitHubClient client)
         {
@@ -26,7 +32,7 @@ namespace Octokit.Reactive
 
             _client = client.Repository.PullRequest;
             _connection = client.Connection;
-            Comment = new ObservablePullRequestReviewCommentsClient(client);
+            ReviewComment = new ObservablePullRequestReviewCommentsClient(client);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
@@ -15,7 +15,7 @@ namespace Octokit.Reactive
     {
         readonly IRepositoryCommentsClient _client;
         readonly IConnection _connection;
-        
+
         public ObservableRepositoryCommentsClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");

--- a/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
@@ -15,7 +15,7 @@ namespace Octokit.Reactive
     {
         readonly IRepositoryHooksClient _client;
         readonly IConnection _connection;
-        
+
         public ObservableRepositoryHooksClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");

--- a/Octokit.Tests.Conventions/ClientConstructorTests.cs
+++ b/Octokit.Tests.Conventions/ClientConstructorTests.cs
@@ -15,7 +15,7 @@ namespace Octokit.Tests.Conventions
             const string constructorTestMethodName = "EnsuresNonNullArguments";
 
             var classes = new HashSet<string>(type.GetNestedTypes().Select(t => t.Name));
-            
+
             if (!classes.Contains(constructorTestClassName))
             {
                 throw new MissingClientConstructorTestClassException(type);

--- a/Octokit.Tests.Conventions/Exception/ApiOptionsMissingException.cs
+++ b/Octokit.Tests.Conventions/Exception/ApiOptionsMissingException.cs
@@ -8,7 +8,8 @@ namespace Octokit.Tests.Conventions
     public class ApiOptionsMissingException : Exception
     {
         public ApiOptionsMissingException(Type type, IEnumerable<MethodInfo> methods)
-            : base(CreateMessage(type, methods)) { }
+            : base(CreateMessage(type, methods))
+        { }
 
         static string CreateMessage(Type type, IEnumerable<MethodInfo> methods)
         {

--- a/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
@@ -30,7 +30,7 @@ namespace Octokit.Tests.Integration.Clients
         public async Task CanGetAuthorization()
         {
             var github = Helper.GetBasicAuthClient();
-            
+
             var authorizations = await github.Authorization.GetAll();
             Assert.NotEmpty(authorizations);
         }

--- a/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
@@ -162,7 +162,7 @@ public class DeploymentStatusClientTests : IDisposable
         var newStatus1 = new NewDeploymentStatus(DeploymentState.Success);
         var newStatus2 = new NewDeploymentStatus(DeploymentState.Success);
         var newStatus3 = new NewDeploymentStatus(DeploymentState.Success);
-        await _deploymentsClient.Status.Create(_context.Repository.Id,_deployment.Id, newStatus1);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus1);
         await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus2);
         await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus3);
 

--- a/Octokit.Tests.Integration/Clients/EventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/EventsClientTests.cs
@@ -109,7 +109,7 @@ namespace Octokit.Tests.Integration.Clients
             public async Task ReturnsDistinctEventsBasedOnStartPage()
             {
                 var github = Helper.GetAuthenticatedClient();
-                 
+
                 var startOptions = new ApiOptions
                 {
                     PageSize = 1,
@@ -134,7 +134,7 @@ namespace Octokit.Tests.Integration.Clients
             public async Task ReturnsDistinctEventsBasedOnStartPageWithRepositoryId()
             {
                 var github = Helper.GetAuthenticatedClient();
-                 
+
                 var startOptions = new ApiOptions
                 {
                     PageSize = 1,
@@ -158,7 +158,7 @@ namespace Octokit.Tests.Integration.Clients
 
         public class TheGetAllIssuesForRepositoryMethod
         {
-            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            [IntegrationTest]
             public async Task CanListIssues()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -167,7 +167,7 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.NotEmpty(issues);
             }
 
-            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            [IntegrationTest]
             public async Task CanListIssuesWithRepositoryId()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -176,7 +176,7 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.NotEmpty(issues);
             }
 
-            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfEventsWithoutStart()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -192,7 +192,7 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal(3, eventInfos.Count);
             }
 
-            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfEventsWithoutStartWitRepositoryId()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -208,7 +208,7 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal(3, eventInfos.Count);
             }
 
-            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfEventsWithStart()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -225,7 +225,7 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal(2, eventInfos.Count);
             }
 
-            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfEventsWithStartWithRepositoryId()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -242,7 +242,7 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal(2, eventInfos.Count);
             }
 
-            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            [IntegrationTest]
             public async Task ReturnsDistinctEventsBasedOnStartPage()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -267,7 +267,7 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
             }
 
-            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            [IntegrationTest]
             public async Task ReturnsDistinctEventsBasedOnStartPageWithRepositoryId()
             {
                 var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
@@ -13,7 +13,7 @@ public class IssueCommentsClientTests
     {
         readonly IGitHubClient _github;
         readonly IIssueCommentsClient _issueCommentsClient;
-        
+
         const string owner = "octokit";
         const string name = "octokit.net";
         const int id = 12067722;
@@ -220,7 +220,7 @@ public class IssueCommentsClientTests
             using (var context = await _github.CreateRepositoryContext(Helper.MakeNameWithTimestamp("IssueCommentsReactionTests")))
             {
                 var commentIds = new List<int>();
-                
+
                 // Create multiple test issues
                 for (int count = 1; count <= numberToCreate; count++)
                 {

--- a/Octokit.Tests.Integration/Clients/IssueReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueReactionsClientTests.cs
@@ -71,7 +71,7 @@ public class IssueReactionsClientTests
             {
                 var newReaction = new NewReaction(reactionType);
 
-                var reaction = await _github.Reaction.CommitComment.Create(_context.RepositoryOwner, _context.RepositoryName, issue.Id, newReaction);
+                var reaction = await _github.Reaction.Issue.Create(_context.RepositoryOwner, _context.RepositoryName, issue.Number, newReaction);
 
                 Assert.IsType<Reaction>(reaction);
                 Assert.Equal(reactionType, reaction.Content);

--- a/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Octokit.Tests.Integration.Clients
 {
-    public class IssueTimelineClientTests :IDisposable
+    public class IssueTimelineClientTests : IDisposable
     {
         private readonly IIssueTimelineClient _issueTimelineClient;
         private readonly IIssuesClient _issuesClient;
@@ -86,7 +86,7 @@ namespace Octokit.Tests.Integration.Clients
 
             var timelineEventInfos = await _issueTimelineClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
             Assert.Equal(1, timelineEventInfos.Count);
-            Assert.Equal(anotherNewIssue.Id, timelineEventInfos[0].Source.Id);
+            Assert.Equal(anotherNewIssue.Id, timelineEventInfos[0].Source.Issue.Id);
         }
 
         [IntegrationTest]
@@ -133,7 +133,7 @@ namespace Octokit.Tests.Integration.Clients
 
             var timelineEventInfos = await _issueTimelineClient.GetAllForIssue(_context.Repository.Id, issue.Number);
             Assert.Equal(1, timelineEventInfos.Count);
-            Assert.Equal(anotherNewIssue.Id, timelineEventInfos[0].Source.Id);
+            Assert.Equal(anotherNewIssue.Id, timelineEventInfos[0].Source.Issue.Id);
         }
 
         public void Dispose()

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -666,9 +666,11 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanFilterByAssigned()
     {
-        var newIssue1 = new NewIssue("An assigned issue") { Body = "Assigning this to myself", Assignee = _context.RepositoryOwner };
-        var newIssue2 = new NewIssue("An unassigned issue") { Body = "A new unassigned issue" };
+        var newIssue1 = new NewIssue("An assigned issue") { Body = "Assigning this to myself" };
+        newIssue1.Assignees.Add(_context.RepositoryOwner);
         await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+
+        var newIssue2 = new NewIssue("An unassigned issue") { Body = "A new unassigned issue" };
         await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
 
         var allIssues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
@@ -692,9 +694,11 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanFilterByAssignedWithRepositoryId()
     {
-        var newIssue1 = new NewIssue("An assigned issue") { Body = "Assigning this to myself", Assignee = _context.RepositoryOwner };
-        var newIssue2 = new NewIssue("An unassigned issue") { Body = "A new unassigned issue" };
+        var newIssue1 = new NewIssue("An assigned issue") { Body = "Assigning this to myself" };
+        newIssue1.Assignees.Add(_context.RepositoryOwner);
         await _issuesClient.Create(_context.Repository.Id, newIssue1);
+
+        var newIssue2 = new NewIssue("An unassigned issue") { Body = "A new unassigned issue" };
         await _issuesClient.Create(_context.Repository.Id, newIssue2);
 
         var allIssues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
@@ -1108,7 +1112,6 @@ public class IssuesClientTests : IDisposable
         var updatedIssue = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
 
         Assert.Empty(updatedIssue.Assignees);
-
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
@@ -139,14 +139,14 @@ public class IssuesLabelsClientTests : IDisposable
 
         for (int i = 0; i < 2; i++)
         {
-            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("test label " + (i + 1), "FFFFF" + (i+1)));
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("test label " + (i + 1), "FFFFF" + (i + 1)));
             labels.Add(label);
             issueUpdate.AddLabel(label.Name);
         }
 
         var issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.Empty(issueLabelsInfo);
-        
+
         var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
         Assert.NotNull(updated);
 
@@ -173,14 +173,14 @@ public class IssuesLabelsClientTests : IDisposable
 
         for (int i = 0; i < 2; i++)
         {
-            var label = await _issuesLabelsClient.Create(_context.Repository.Id, new NewLabel("test label " + (i + 1), "FFFFF" + (i+1)));
+            var label = await _issuesLabelsClient.Create(_context.Repository.Id, new NewLabel("test label " + (i + 1), "FFFFF" + (i + 1)));
             labels.Add(label);
             issueUpdate.AddLabel(label.Name);
         }
 
         var issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.Repository.Id, issue.Number);
         Assert.Empty(issueLabelsInfo);
-        
+
         var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
         Assert.NotNull(updated);
 
@@ -202,7 +202,7 @@ public class IssuesLabelsClientTests : IDisposable
     {
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewIssue("A test issue") { Body = "A new unassigned issue" });
         var issueUpdate = new IssueUpdate();
-        
+
         for (int i = 0; i < 2; i++)
         {
             var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("test label " + (i + 1), "FFFFF" + (i + 1)));
@@ -243,7 +243,7 @@ public class IssuesLabelsClientTests : IDisposable
     {
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewIssue("A test issue") { Body = "A new unassigned issue" });
         var issueUpdate = new IssueUpdate();
-        
+
         for (int i = 0; i < 2; i++)
         {
             var label = await _issuesLabelsClient.Create(_context.Repository.Id, new NewLabel("test label " + (i + 1), "FFFFF" + (i + 1)));
@@ -521,7 +521,7 @@ public class IssuesLabelsClientTests : IDisposable
         var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
-        
+
         var issueLabelsInfo = await _issuesLabelsClient.GetAllForMilestone(_context.RepositoryOwner, _context.RepositoryName, milestone.Number);
         Assert.Empty(issueLabelsInfo);
 
@@ -547,7 +547,7 @@ public class IssuesLabelsClientTests : IDisposable
         var label = await _issuesLabelsClient.Create(_context.Repository.Id, newLabel);
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
-        
+
         var issueLabelsInfo = await _issuesLabelsClient.GetAllForMilestone(_context.Repository.Id, milestone.Number);
         Assert.Empty(issueLabelsInfo);
 
@@ -853,7 +853,7 @@ public class IssuesLabelsClientTests : IDisposable
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         Assert.NotNull(issue);
 
-        await _issuesLabelsClient.AddToIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new []{ label.Name });
+        await _issuesLabelsClient.AddToIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new[] { label.Name });
 
         var labels = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
@@ -895,7 +895,7 @@ public class IssuesLabelsClientTests : IDisposable
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         Assert.NotNull(issue);
 
-        await _issuesLabelsClient.AddToIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new []{ label.Name });
+        await _issuesLabelsClient.AddToIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new[] { label.Name });
         await _issuesLabelsClient.RemoveAllFromIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         var labels = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
@@ -935,7 +935,7 @@ public class IssuesLabelsClientTests : IDisposable
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         Assert.NotNull(issue);
 
-        await _issuesLabelsClient.AddToIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new []{ label.Name });
+        await _issuesLabelsClient.AddToIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new[] { label.Name });
         await _issuesLabelsClient.RemoveFromIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, label.Name);
 
         var labels = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
@@ -978,7 +978,7 @@ public class IssuesLabelsClientTests : IDisposable
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
         Assert.NotNull(issue);
 
-        await _issuesLabelsClient.AddToIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new []{ label1.Name });
+        await _issuesLabelsClient.AddToIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new[] { label1.Name });
         await _issuesLabelsClient.ReplaceAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new[] { label2.Name });
 
         var labels = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);

--- a/Octokit.Tests.Integration/Clients/MigrationsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MigrationsClientTests.cs
@@ -81,11 +81,11 @@ public class MigrationsClientTests : IDisposable
     {
         while (!isExported)
         {
-            Thread.Sleep(2000);    
+            Thread.Sleep(2000);
         }
 
         var contents = await _gitHub.Migration.Migrations.GetArchive(_orgName, _migrationContext.Id);
-        
+
         Assert.NotEmpty(contents);
     }
 
@@ -127,6 +127,6 @@ public class MigrationsClientTests : IDisposable
 
     public void Dispose()
     {
-        _repos.ForEach( (repo) => repo.Dispose() );
+        _repos.ForEach((repo) => repo.Dispose());
     }
 }

--- a/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
@@ -94,7 +94,7 @@ public class MilestonesClientTests : IDisposable
         var result1 = await _milestonesClient.Get(_context.Repository.Id, created.Number);
         Assert.Equal("a milestone", result1.Title);
 
-        await _milestonesClient.Update(_context.Repository.Id, created.Number, new MilestoneUpdate {Title = "New title"});
+        await _milestonesClient.Update(_context.Repository.Id, created.Number, new MilestoneUpdate { Title = "New title" });
 
         var result2 = await _milestonesClient.Get(_context.Repository.Id, created.Number);
         Assert.Equal("New title", result2.Title);
@@ -315,7 +315,7 @@ public class MilestonesClientTests : IDisposable
         await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
         await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
         await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
-        
+
         var startOptions = new ApiOptions
         {
             PageSize = 1,
@@ -345,7 +345,7 @@ public class MilestonesClientTests : IDisposable
         await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
         await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
         await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
-        
+
         var startOptions = new ApiOptions
         {
             PageSize = 1,
@@ -486,7 +486,7 @@ public class MilestonesClientTests : IDisposable
             PageCount = 1,
             StartPage = 2
         };
-        
+
         var secondPage = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, milestoneRequest, skipStartOptions);
 
         Assert.NotEqual(firstPage[0].Number, secondPage[0].Number);
@@ -518,7 +518,7 @@ public class MilestonesClientTests : IDisposable
             PageCount = 1,
             StartPage = 2
         };
-        
+
         var secondPage = await _milestonesClient.GetAllForRepository(_context.Repository.Id, milestoneRequest, skipStartOptions);
 
         Assert.NotEqual(firstPage[0].Number, secondPage[0].Number);

--- a/Octokit.Tests.Integration/Clients/OrganizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Octokit.Tests.Integration.Clients
@@ -18,30 +19,88 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [GitHubEnterpriseTest]
-            public async Task CanListOrganizations()
-            {
-                string orgLogin = Helper.MakeNameWithTimestamp("MyOrganization");
-                string orgName = string.Concat(orgLogin, " Display Name");
-
-                var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.UserName, orgName);
-                var organization = await
-                    _github.Enterprise.Organization.Create(newOrganization);
-
-                Assert.NotNull(organization);
-
-                var milestones = await _organizationsClient.GetAllForCurrent();
-
-                Assert.NotEmpty(milestones);
-            }
-
-            [GitHubEnterpriseTest]
-            public async Task ReturnsCorrectCountOfOrganizationsWithoutStart()
+            public async Task CanListAllOrganizations()
             {
                 string orgLogin1 = Helper.MakeNameWithTimestamp("MyOrganization1");
                 string orgName1 = string.Concat(orgLogin1, " Display Name 1");
                 string orgLogin2 = Helper.MakeNameWithTimestamp("MyOrganization2");
                 string orgName2 = string.Concat(orgLogin2, " Display Name 2");
-                
+
+                var newOrganization1 = new NewOrganization(orgLogin1, EnterpriseHelper.UserName, orgName1);
+                var newOrganization2 = new NewOrganization(orgLogin2, EnterpriseHelper.UserName, orgName2);
+                await _github.Enterprise.Organization.Create(newOrganization1);
+                await _github.Enterprise.Organization.Create(newOrganization2);
+
+                var organizations = await _organizationsClient.GetAll();
+
+                Assert.Contains(organizations, (org => org.Login == orgLogin1));
+                Assert.Contains(organizations, (org => org.Login == orgLogin2));
+            }
+
+            [GitHubEnterpriseTest]
+            public async Task ReturnsCorrectOrganizationsWithSince()
+            {
+                string orgLogin1 = Helper.MakeNameWithTimestamp("MyOrganization1");
+                string orgName1 = string.Concat(orgLogin1, " Display Name 1");
+                string orgLogin2 = Helper.MakeNameWithTimestamp("MyOrganization2");
+                string orgName2 = string.Concat(orgLogin2, " Display Name 2");
+                string orgLogin3 = Helper.MakeNameWithTimestamp("MyOrganization3");
+                string orgName3 = string.Concat(orgLogin3, " Display Name 3");
+
+                var newOrganization1 = new NewOrganization(orgLogin1, EnterpriseHelper.UserName, orgName1);
+                var newOrganization2 = new NewOrganization(orgLogin2, EnterpriseHelper.UserName, orgName2);
+                var newOrganization3 = new NewOrganization(orgLogin3, EnterpriseHelper.UserName, orgName3);
+
+                var createdOrganization1 = await _github.Enterprise.Organization.Create(newOrganization1);
+                var createdOrganization2 = await _github.Enterprise.Organization.Create(newOrganization2);
+                var createdOrganization3 = await _github.Enterprise.Organization.Create(newOrganization3);
+
+                var requestParameter = new OrganizationRequest(createdOrganization1.Id);
+
+                var organizations = await _organizationsClient.GetAll(requestParameter);
+
+                Assert.DoesNotContain(organizations, (org => org.Login == orgLogin1));
+                Assert.Contains(organizations, (org => org.Login == orgLogin2));
+                Assert.Contains(organizations, (org => org.Login == orgLogin3));
+            }
+        }
+
+        public class TheGetAllForCurrentMethod
+        {
+            readonly IGitHubClient _github;
+            readonly IOrganizationsClient _organizationsClient;
+
+            public TheGetAllForCurrentMethod()
+            {
+                _github = EnterpriseHelper.GetAuthenticatedClient();
+
+                _organizationsClient = _github.Organization;
+            }
+
+            [GitHubEnterpriseTest]
+            public async Task CanListUserOrganizations()
+            {
+                string orgLogin = Helper.MakeNameWithTimestamp("MyOrganization");
+                string orgName = string.Concat(orgLogin, " Display Name");
+
+                var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.UserName, orgName);
+                var organization = await _github.Enterprise.Organization.Create(newOrganization);
+
+                Assert.NotNull(organization);
+
+                var organizations = await _organizationsClient.GetAllForCurrent();
+
+                Assert.NotEmpty(organizations);
+            }
+
+            [GitHubEnterpriseTest]
+            public async Task ReturnsCorrectCountOfUserOrganizationsWithoutStart()
+            {
+                string orgLogin1 = Helper.MakeNameWithTimestamp("MyOrganization1");
+                string orgName1 = string.Concat(orgLogin1, " Display Name 1");
+                string orgLogin2 = Helper.MakeNameWithTimestamp("MyOrganization2");
+                string orgName2 = string.Concat(orgLogin2, " Display Name 2");
+
                 var newOrganization1 = new NewOrganization(orgLogin1, EnterpriseHelper.UserName, orgName1);
                 var newOrganization2 = new NewOrganization(orgLogin2, EnterpriseHelper.UserName, orgName2);
                 await _github.Enterprise.Organization.Create(newOrganization1);
@@ -59,7 +118,7 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [GitHubEnterpriseTest]
-            public async Task ReturnsCorrectCountOfOrganizationsWithStart()
+            public async Task ReturnsCorrectCountOfUserOrganizationsWithStart()
             {
                 string orgLogin1 = Helper.MakeNameWithTimestamp("MyOrganization1");
                 string orgName1 = string.Concat(orgLogin1, " Display Name 1");

--- a/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
@@ -20,7 +20,7 @@ namespace Octokit.Tests.Integration.Clients
             [IntegrationTest]
             public async Task ReturnsMembers()
             {
-                var members = await 
+                var members = await
                     _gitHub.Organization.Member.GetAll(_organizationFixture);
                 Assert.NotEmpty(members);
             }
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var members = await _gitHub.Organization.Member.GetAll(_organizationFixture, options);
-                
+
                 Assert.Equal(1, members.Count);
             }
 

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentReactionsClientTests.cs
@@ -20,7 +20,7 @@ public class PullRequestReviewCommentReactionsClientTests : IDisposable
     {
         _github = Helper.GetAuthenticatedClient();
 
-        _client = _github.PullRequest.Comment;
+        _client = _github.PullRequest.ReviewComment;
 
         // We'll create a pull request that can be used by most tests
         _context = _github.CreateRepositoryContext("test-repo").Result;

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -20,7 +20,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     {
         _github = Helper.GetAuthenticatedClient();
 
-        _client = _github.PullRequest.Comment;
+        _client = _github.PullRequest.ReviewComment;
 
         // We'll create a pull request that can be used by most tests
         _context = _github.CreateRepositoryContext("test-repo").Result;

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -406,7 +406,6 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var pullRequestComments = await _client.GetAllForRepository(_context.Repository.Id);
 
         AssertComments(pullRequestComments, commentsToCreate, position);
-
     }
 
     [IntegrationTest]
@@ -855,7 +854,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
 
 
         var repoName = context.RepositoryName;
-        
+
         // Creating a commit in master
 
         var createdCommitInMaster = await CreateCommit(repoName, "Hello World!", "README.md", "heads/master", "A master commit message");

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -76,6 +76,52 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanGetWithAssigneesForRepository()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        // Add an assignee
+        var issueUpdate = new IssueUpdate();
+        issueUpdate.AddAssignee(Helper.UserName);
+        await _github.Issue.Update(Helper.UserName, _context.RepositoryName, result.Number, issueUpdate);
+
+        // Retrieve the Pull Requests
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+        Assert.Equal(Helper.UserName, pullRequests[0].Assignee.Login);
+        Assert.Equal(1, pullRequests[0].Assignees.Count);
+        Assert.True(pullRequests[0].Assignees.Any(x => x.Login == Helper.UserName));
+    }
+
+    [IntegrationTest]
+    public async Task CanGetWithAssigneesForRepositoryWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(_context.Repository.Id, newPullRequest);
+
+        // Add an assignee
+        var issueUpdate = new IssueUpdate();
+        issueUpdate.AddAssignee(Helper.UserName);
+        await _github.Issue.Update(_context.Repository.Id, result.Number, issueUpdate);
+
+        // Retrieve the Pull Requests
+        var pullRequests = await _fixture.GetAllForRepository(_context.Repository.Id);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+        Assert.Equal(Helper.UserName, pullRequests[0].Assignee.Login);
+        Assert.Equal(1, pullRequests[0].Assignees.Count);
+        Assert.True(pullRequests[0].Assignees.Any(x => x.Login == Helper.UserName));
+    }
+
+    [IntegrationTest]
     public async Task ReturnsCorrectCountOfPullRequestsWithoutStart()
     {
         await CreateTheWorld();

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -59,6 +59,7 @@ public class PullRequestsClientTests : IDisposable
 
         Assert.Equal(1, pullRequests.Count);
         Assert.Equal(result.Title, pullRequests[0].Title);
+        Assert.True(pullRequests[0].Id > 0);
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -836,7 +836,7 @@ public class ReleasesClientTests
 
             await _releaseClient.Delete(_context.RepositoryOwner, _context.RepositoryName, createdRelease.Id);
 
-            Assert.ThrowsAsync<NotFoundException>(async ()=> await _releaseClient.Get(_context.RepositoryOwner, _context.RepositoryName, createdRelease.Id));
+            Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.Get(_context.RepositoryOwner, _context.RepositoryName, createdRelease.Id));
         }
 
         [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -231,7 +231,7 @@ public class RepositoriesClientTests
             }
         }
 
-        [PaidAccountTest(Skip="Paid plans now have unlimited repositories. We shouldn't test this now.")]
+        [PaidAccountTest(Skip = "Paid plans now have unlimited repositories. We shouldn't test this now.")]
         public async Task ThrowsPrivateRepositoryQuotaExceededExceptionWhenOverQuota()
         {
             var github = Helper.GetAuthenticatedClient();
@@ -782,7 +782,7 @@ public class RepositoriesClientTests
         public async Task ReturnsRepositoriesForOrganization()
         {
             var github = Helper.GetAuthenticatedClient();
-            
+
             var options = new ApiOptions
             {
                 PageSize = 20,
@@ -1134,7 +1134,7 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var firstPage = await github.Repository.GetAllContributors("ruby", "ruby",  true, firstPageOptions);
+            var firstPage = await github.Repository.GetAllContributors("ruby", "ruby", true, firstPageOptions);
 
             var secondPageOptions = new ApiOptions
             {
@@ -1646,7 +1646,7 @@ public class RepositoriesClientTests
 
     public class TheGetAllTeamsMethod
     {
-        [IntegrationTest(Skip="Test requires administration rights to access this endpoint")]
+        [IntegrationTest(Skip = "Test requires administration rights to access this endpoint")]
         public async Task GetsAllTeams()
         {
             var github = Helper.GetAuthenticatedClient();
@@ -1656,7 +1656,7 @@ public class RepositoriesClientTests
             Assert.NotEmpty(branches);
         }
 
-        [IntegrationTest(Skip="Test requires administration rights to access this endpoint")]
+        [IntegrationTest(Skip = "Test requires administration rights to access this endpoint")]
         public async Task GetsAllTeamsWithRepositoryId()
         {
             var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
@@ -683,7 +683,7 @@ public class RepositoryBranchesClientTests
     public class TheGetRequiredStatusChecksContextsMethod : IDisposable
     {
         IRepositoryBranchesClient _client;
-        RepositoryContext _userRepoContext;        
+        RepositoryContext _userRepoContext;
 
         public TheGetRequiredStatusChecksContextsMethod()
         {
@@ -741,7 +741,7 @@ public class RepositoryBranchesClientTests
             var repoName = _userRepoContext.RepositoryName;
             var update = new List<string>() { "build2" };
             var requiredStatusChecksContexts = await _client.UpdateRequiredStatusChecksContexts(repoOwner, repoName, "master", update);
-                       
+
             Assert.Equal(1, requiredStatusChecksContexts.Count);
         }
 
@@ -867,7 +867,7 @@ public class RepositoryBranchesClientTests
             var repoOwner = _orgRepoContext.RepositoryContext.RepositoryOwner;
             var repoName = _orgRepoContext.RepositoryContext.RepositoryName;
             var restrictions = await _client.GetProtectedBranchRestrictions(repoOwner, repoName, "master");
-            
+
             Assert.Equal(1, restrictions.Teams.Count);
             Assert.Equal(0, restrictions.Users.Count);
         }
@@ -877,7 +877,7 @@ public class RepositoryBranchesClientTests
         {
             var repoId = _orgRepoContext.RepositoryContext.RepositoryId;
             var restrictions = await _client.GetProtectedBranchRestrictions(repoId, "master");
-            
+
             Assert.Equal(1, restrictions.Teams.Count);
             Assert.Equal(0, restrictions.Users.Count);
         }

--- a/Octokit.Tests.Integration/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommentsClientTests.cs
@@ -499,7 +499,7 @@ public class RepositoryCommentsClientTests
             {
                 var newReaction = new NewReaction(reactionType);
 
-                var reaction = await _github.Reaction.Issue.Create(_context.RepositoryOwner, _context.RepositoryName, result.Id, newReaction);
+                var reaction = await _github.Reaction.CommitComment.Create(_context.RepositoryOwner, _context.RepositoryName, result.Id, newReaction);
 
                 Assert.IsType<Reaction>(reaction);
                 Assert.Equal(reactionType, reaction.Content);

--- a/Octokit.Tests.Integration/Clients/RepositoryHooksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryHooksClientTests.cs
@@ -48,7 +48,7 @@ namespace Octokit.Tests.Integration.Clients
             public async Task ReturnsCorrectCountOfHooksWithoutStart()
             {
                 var github = Helper.GetAuthenticatedClient();
-                
+
                 var options = new ApiOptions
                 {
                     PageSize = 5,
@@ -64,7 +64,7 @@ namespace Octokit.Tests.Integration.Clients
             public async Task ReturnsCorrectCountOfHooksWithoutStartWithRepositoryId()
             {
                 var github = Helper.GetAuthenticatedClient();
-                
+
                 var options = new ApiOptions
                 {
                     PageSize = 5,

--- a/Octokit.Tests.Integration/Clients/RepositoryPagesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryPagesClientTests.cs
@@ -18,14 +18,14 @@ public class RepositoryPagesClientTests
             _repositoryPagesClient = github.Repository.Page;
         }
 
-        [IntegrationTest(Skip= "These tests require repository admin rights - see https://github.com/octokit/octokit.net/issues/1263 for discussion")]
+        [IntegrationTest(Skip = "These tests require repository admin rights - see https://github.com/octokit/octokit.net/issues/1263 for discussion")]
         public async Task ReturnsMetadata()
         {
             var data = await _repositoryPagesClient.Get(owner, name);
             Assert.Equal("https://api.github.com/repos/octokit/octokit.net/pages", data.Url);
         }
 
-        [IntegrationTest(Skip= "These tests require repository admin rights - see https://github.com/octokit/octokit.net/issues/1263 for discussion")]
+        [IntegrationTest(Skip = "These tests require repository admin rights - see https://github.com/octokit/octokit.net/issues/1263 for discussion")]
         public async Task ReturnsMetadataWithRepositoryId()
         {
             var data = await _repositoryPagesClient.Get(repositoryId);

--- a/Octokit.Tests.Integration/Clients/StarredClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/StarredClientTests.cs
@@ -32,7 +32,7 @@ namespace Octokit.Tests.Integration.Clients
         {
             var repositories = await _fixture.GetAllForCurrent();
             Assert.NotEmpty(repositories);
-            
+
             var repo = repositories.FirstOrDefault(repository => repository.Owner.Login == _repositoryContext.RepositoryOwner && repository.Name == _repositoryContext.RepositoryName);
             Assert.NotNull(repo);
         }

--- a/Octokit.Tests.Integration/Clients/TagsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TagsClientTests.cs
@@ -125,7 +125,6 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal(gitTag.Verification.Reason, VerificationReason.Unsigned);
                 Assert.Null(gitTag.Verification.Signature);
                 Assert.Null(gitTag.Verification.Payload);
-
             }
         }
     }

--- a/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
@@ -41,7 +41,7 @@ namespace Octokit.Tests.Integration.Clients
 
             Assert.NotEmpty(emails);
         }
-        
+
         const string testEmailAddress = "hahaha-not-a-real-email@foo.com";
 
         [IntegrationTest(Skip = "this isn't passing in CI - i hate past me right now")]

--- a/Octokit.Tests.Integration/Clients/UserKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserKeysClientTests.cs
@@ -57,19 +57,21 @@ namespace Octokit.Tests.Integration.Clients
         [IntegrationTest]
         public async Task CanCreateAndDeleteKey()
         {
-            // Create a key
-            string keyTitle = "title";
-            string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAjo4DqFKg8dOxiz/yjypmN1A4itU5QOStyYrfOFuTinesU/2zm9hqxJ5BctIhgtSHJ5foxkhsiBji0qrUg73Q25BThgNg8YFE8njr4EwjmqSqW13akx/zLV0GFFU0SdJ2F6rBldhi93lMnl0ex9swBqa3eLTY8C+HQGBI6MQUMw+BKp0oFkz87Kv+Pfp6lt/Uo32ejSxML1PT5hTH5n+fyl0ied+sRmPGZWmWoHB5Bc9mox7lB6I6A/ZgjtBqbEEn4HQ2/6vp4ojKfSgA4Mm7XMu0bZzX0itKjH1QWD9Lr5apV1cmZsj49Xf8SHucTtH+bq98hb8OOXEGFzplwsX2MQ==";
             var github = Helper.GetAuthenticatedClient();
 
-            var key = await github.User.GitSshKey.Create(new NewPublicKey(keyTitle, keyData));
+            // Use context helper to create/destroy a key safely (to avoid test failures when a key exists due to not having been deleted)
+            string keyTitle = null;
+            string keyData = null;
+            using (var context = await github.CreatePublicKeyContext())
+            {
+                var observable = github.User.GitSshKey.Get(context.KeyId);
+                var key = await observable;
 
-            Assert.NotNull(key);
-            Assert.Equal(key.Title, "title");
-            Assert.Equal(key.Key, keyData);
+                Assert.NotNull(key);
 
-            // Delete key
-            await github.User.GitSshKey.Delete(key.Id);
+                keyTitle = key.Title;
+                keyData = key.Key;
+            }
 
             // Verify key no longer exists
             var keys = await github.User.GitSshKey.GetAllForCurrent();

--- a/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
@@ -44,7 +44,7 @@ namespace Octokit.Tests.Integration.Helpers
         {
             // Create a key
             string keyTitle = "title";
-            string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAjo4DqFKg8dOxiz/yjypmN1A4itU5QOStyYrfOFuTinesU/2zm9hqxJ5BctIhgtSHJ5foxkhsiBji0qrUg73Q25BThgNg8YFE8njr4EwjmqSqW13akx/zLV0GFFU0SdJ2F6rBldhi93lMnl0ex9swBqa3eLTY8C+HQGBI6MQUMw+BKp0oFkz87Kv+Pfp6lt/Uo32ejSxML1PT5hTH5n+fyl0ied+sRmPGZWmWoHB5Bc9mox7lB6I6A/ZgjtBqbEEn4HQ2/6vp4ojKfSgA4Mm7XMu0bZzX0itKjH1QWD9Lr5apV1cmZsj49Xf8SHucTtH+bq98hb8OOXEGFzplwsX2MQ==";
+            string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAq42HufbSy1BUbZTdKyEy8nX44gdchbh1A/cYuVFkRXETrFr6XYLETi4tauXGS3Wp3E4s3oG272O4JW+fIBX0kuOJXnRgYz52H3BDk6aY9B0ny+PYFJrYrpG43px5EVfojj9o7oxugNq4zLCGqWTqZU1maTf5T4Mopjt0ggA7cyNnM5B645cBxXjD2KNfrTIyLI+meYxptzjRiB6fHLGFRA9fxpVqUnbq7EcGbwsTlILRuEPt58hZ9He88M45m0F8rkVZOewt4JSzsLsC+sQs+h/LXI8dbrg6xWpxJVi0trzYuMuY/MwygloWKtaFQYuPkJ7yqMZ3Aew+J3DupF6uxQ==";
 
             var key = await client.User.GitSshKey.Create(new NewPublicKey(keyTitle, keyData));
 

--- a/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
@@ -46,7 +46,7 @@ namespace Octokit.Tests.Integration.Helpers
         {
             // Create a key
             string keyTitle = "title";
-            string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAjo4DqFKg8dOxiz/yjypmN1A4itU5QOStyYrfOFuTinesU/2zm9hqxJ5BctIhgtSHJ5foxkhsiBji0qrUg73Q25BThgNg8YFE8njr4EwjmqSqW13akx/zLV0GFFU0SdJ2F6rBldhi93lMnl0ex9swBqa3eLTY8C+HQGBI6MQUMw+BKp0oFkz87Kv+Pfp6lt/Uo32ejSxML1PT5hTH5n+fyl0ied+sRmPGZWmWoHB5Bc9mox7lB6I6A/ZgjtBqbEEn4HQ2/6vp4ojKfSgA4Mm7XMu0bZzX0itKjH1QWD9Lr5apV1cmZsj49Xf8SHucTtH+bq98hb8OOXEGFzplwsX2MQ==";
+            string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAq42HufbSy1BUbZTdKyEy8nX44gdchbh1A/cYuVFkRXETrFr6XYLETi4tauXGS3Wp3E4s3oG272O4JW+fIBX0kuOJXnRgYz52H3BDk6aY9B0ny+PYFJrYrpG43px5EVfojj9o7oxugNq4zLCGqWTqZU1maTf5T4Mopjt0ggA7cyNnM5B645cBxXjD2KNfrTIyLI+meYxptzjRiB6fHLGFRA9fxpVqUnbq7EcGbwsTlILRuEPt58hZ9He88M45m0F8rkVZOewt4JSzsLsC+sQs+h/LXI8dbrg6xWpxJVi0trzYuMuY/MwygloWKtaFQYuPkJ7yqMZ3Aew+J3DupF6uxQ==";
 
             var key = await client.User.GitSshKey.Create(new NewPublicKey(keyTitle, keyData));
 

--- a/Octokit.Tests.Integration/Reactive/ObservableCommitStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableCommitStatusClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Integration.Reactive
             readonly ObservableCommitStatusClient _commitStatusClient;
             const string owner = "octokit";
             const string name = "octokit.net";
-            const string reference = "1335f37";   
+            const string reference = "1335f37";
 
             public TheGetAllMethod()
             {
@@ -37,7 +37,7 @@ namespace Octokit.Tests.Integration.Reactive
                     PageCount = 1
                 };
 
-                var commitStatus = await _commitStatusClient.GetAll(owner, name ,reference , options).ToList();
+                var commitStatus = await _commitStatusClient.GetAll(owner, name, reference, options).ToList();
 
                 Assert.Equal(2, commitStatus.Count);
             }
@@ -75,10 +75,10 @@ namespace Octokit.Tests.Integration.Reactive
                     StartPage = 2
                 };
 
-                var secondPage = await _commitStatusClient.GetAll(owner, name, reference,skipStartOptions).ToList();             
+                var secondPage = await _commitStatusClient.GetAll(owner, name, reference, skipStartOptions).ToList();
 
                 Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
-                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);                
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
             }
         }
     }

--- a/Octokit.Tests.Integration/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableEventsClientTests.cs
@@ -79,12 +79,10 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstEventsPage[3].Id, secondEventsPage[3].Id);
                 Assert.NotEqual(firstEventsPage[4].Id, secondEventsPage[4].Id);
             }
-
         }
 
         public class TheGetAllForRepositoryMethod
         {
-
             readonly ObservableEventsClient _eventsClient;
             const string owner = "octokit";
             const string name = "octokit.net";
@@ -156,7 +154,6 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstRepositoryEventsPage[3].Id, secondRepositoryEventsPage[3].Id);
                 Assert.NotEqual(firstRepositoryEventsPage[4].Id, secondRepositoryEventsPage[4].Id);
             }
-
         }
 
         public class TheGetAllIssuesForRepositoryMethod
@@ -240,7 +237,6 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstRepositoryEventsPage[3].Id, secondRepositoryEventsPage[3].Id);
                 Assert.NotEqual(firstRepositoryEventsPage[4].Id, secondRepositoryEventsPage[4].Id);
             }
-
         }
 
         public class TheGetAllForRepositoryNetworkMethod
@@ -316,14 +312,12 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstRepositoryNetworkEventsPage[3].Id, secondRepositoryNetworkEventsPage[3].Id);
                 Assert.NotEqual(firstRepositoryNetworkEventsPage[4].Id, secondRepositoryNetworkEventsPage[4].Id);
             }
-
         }
 
         public class TheGetAllForOrganizationMethod
         {
-
             readonly ObservableEventsClient _eventsClient;
-            const string organization = "octokit";            
+            const string organization = "octokit";
 
             public TheGetAllForOrganizationMethod()
             {
@@ -360,7 +354,7 @@ namespace Octokit.Tests.Integration.Reactive
                     PageSize = 5,
                     PageCount = 1,
                     StartPage = 2
-                };  
+                };
 
                 var organizationEvents = await _eventsClient.GetAllForOrganization(organization, options).ToList();
 
@@ -393,7 +387,6 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstOrganizationEventsPage[3].Id, secondOrganizationEventsPage[3].Id);
                 Assert.NotEqual(firstOrganizationEventsPage[4].Id, secondOrganizationEventsPage[4].Id);
             }
-
         }
 
         public class TheGetAllUserReceivedMethod
@@ -473,7 +466,6 @@ namespace Octokit.Tests.Integration.Reactive
 
         public class TheGetAllUserReceivedPublicMethod
         {
-
             readonly ObservableEventsClient _eventsClient;
             const string user = "shiftkey";
 
@@ -545,7 +537,6 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstUserReceivedPublicEventsPage[3].Id, secondUserReceivedPublicEventsPage[3].Id);
                 Assert.NotEqual(firstUserReceivedPublicEventsPage[4].Id, secondUserReceivedPublicEventsPage[4].Id);
             }
-
         }
 
         public class TheGetAllUserPerformedMethod
@@ -585,7 +576,7 @@ namespace Octokit.Tests.Integration.Reactive
             {
                 var options = new ApiOptions
                 {
-                    PageSize = 5,   
+                    PageSize = 5,
                     PageCount = 1,
                     StartPage = 2
                 };
@@ -621,7 +612,6 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstUserPerformedEventsPage[3].Id, secondUserPerformedEventsPage[3].Id);
                 Assert.NotEqual(firstUserPerformedEventsPage[4].Id, secondUserPerformedEventsPage[4].Id);
             }
-
         }
 
         public class TheGetAllUserPerformedPublicMethod
@@ -697,7 +687,6 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstUserPerformedPublicEventsPage[3].Id, secondUserPerformedPublicEventsPage[3].Id);
                 Assert.NotEqual(firstUserPerformedPublicEventsPage[4].Id, secondUserPerformedPublicEventsPage[4].Id);
             }
-
         }
 
         public class TheGetAllForAnOrganizationMethod
@@ -717,7 +706,7 @@ namespace Octokit.Tests.Integration.Reactive
             [IntegrationTest]
             public async Task ReturnsUserOrganizationEvents()
             {
-                var userOrganizationEvents = await _eventsClient.GetAllForAnOrganization(_user,_organization).ToList();
+                var userOrganizationEvents = await _eventsClient.GetAllForAnOrganization(_user, _organization).ToList();
 
                 Assert.NotEmpty(userOrganizationEvents);
             }
@@ -777,7 +766,6 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstUserOrganizationEventsPage[3].Id, secondUserOrganizationEventsPage[3].Id);
                 Assert.NotEqual(firstUserOrganizationEventsPage[4].Id, secondUserOrganizationEventsPage[4].Id);
             }
-
         }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableEventsClientTests.cs
@@ -170,7 +170,7 @@ namespace Octokit.Tests.Integration.Reactive
                 _eventsClient = new ObservableEventsClient(Helper.GetAuthenticatedClient());
             }
 
-            [IntegrationTest(Skip = "These tests just don't work any more")]
+            [IntegrationTest]
             public async Task ReturnsRepositoryEvents()
             {
                 var options = new ApiOptions
@@ -185,7 +185,7 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEmpty(repositoryEvents);
             }
 
-            [IntegrationTest(Skip = "These tests just don't work any more")]
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfRepositoryEventsWithoutStart()
             {
                 var options = new ApiOptions
@@ -199,7 +199,7 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.Equal(5, repositoryEvents.Count);
             }
 
-            [IntegrationTest(Skip = "These tests just don't work any more")]
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfRepositoryEventsWithStart()
             {
                 var options = new ApiOptions
@@ -214,7 +214,7 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.Equal(5, repositoryEvents.Count);
             }
 
-            [IntegrationTest(Skip = "These tests just don't work any more")]
+            [IntegrationTest]
             public async Task ReturnsDistinctRepositoryEventsBasedOnStartPage()
             {
                 var startOptions = new ApiOptions

--- a/Octokit.Tests.Integration/Reactive/ObservableFollowersClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableFollowersClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Octokit.Reactive;
 using Xunit;
@@ -9,7 +10,7 @@ namespace Octokit.Tests.Integration.Reactive
     {
         public class TheGetAllForCurrentMethod
         {
-            readonly ObservableFollowersClient _followersClient;            
+            readonly ObservableFollowersClient _followersClient;
 
             public TheGetAllForCurrentMethod()
             {
@@ -18,7 +19,7 @@ namespace Octokit.Tests.Integration.Reactive
                 _followersClient = new ObservableFollowersClient(github);
             }
 
-            [IntegrationTest]       
+            [IntegrationTest]
             public async Task ReturnsFollowers()
             {
                 var followers = await _followersClient.GetAllForCurrent().ToList();
@@ -30,7 +31,7 @@ namespace Octokit.Tests.Integration.Reactive
             public async Task ReturnsCorrectCountOfFollowersWithoutStart()
             {
                 var options = new ApiOptions
-                {   
+                {
                     PageSize = 1,
                     PageCount = 1
                 };
@@ -75,7 +76,7 @@ namespace Octokit.Tests.Integration.Reactive
 
                 var secondFollowersPage = await _followersClient.GetAllForCurrent(skipStartOptions).ToList();
 
-                Assert.NotEqual(firstFollowersPage[0].Id, secondFollowersPage[0].Id);               
+                Assert.NotEqual(firstFollowersPage[0].Id, secondFollowersPage[0].Id);
             }
         }
 
@@ -153,15 +154,19 @@ namespace Octokit.Tests.Integration.Reactive
             }
         }
 
-        public class TheGetAllFollowingForCurrentMethod
+        public class TheGetAllFollowingForCurrentMethod : IDisposable
         {
-            readonly ObservableFollowersClient _followersClient;            
+            readonly ObservableFollowersClient _followersClient;
 
             public TheGetAllFollowingForCurrentMethod()
             {
                 var github = Helper.GetAuthenticatedClient();
 
                 _followersClient = new ObservableFollowersClient(github);
+
+                // Follow someone to set initial state
+                _followersClient.Follow("alfhenrik").ToList();
+                _followersClient.Follow("ryangribble").ToList();
             }
 
             [IntegrationTest]
@@ -221,7 +226,13 @@ namespace Octokit.Tests.Integration.Reactive
 
                 var secondFollowingPage = await _followersClient.GetAllFollowingForCurrent(skipStartOptions).ToList();
 
-                Assert.NotEqual(firstFollowingPage[0].Id, secondFollowingPage[0].Id);                
+                Assert.NotEqual(firstFollowingPage[0].Id, secondFollowingPage[0].Id);
+            }
+
+            public void Dispose()
+            {
+                _followersClient.Unfollow("alfhenrik");
+                _followersClient.Unfollow("ryangribble");
             }
         }
 

--- a/Octokit.Tests.Integration/Reactive/ObservableGistCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistCommentsClientTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Octokit.Tests.Integration.Reactive
 {
     public class ObservableGistCommentsClientTests
-    {   
+    {
         public class TheGetAllForGistMethod
         {
             readonly ObservableGistCommentsClient _gistCommentsClient;
@@ -79,8 +79,8 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstCommentsPage[0].Id, secondCommentsPage[0].Id);
                 Assert.NotEqual(firstCommentsPage[1].Id, secondCommentsPage[1].Id);
                 Assert.NotEqual(firstCommentsPage[2].Id, secondCommentsPage[2].Id);
-                Assert.NotEqual(firstCommentsPage[3].Id, secondCommentsPage[3].Id);                
+                Assert.NotEqual(firstCommentsPage[3].Id, secondCommentsPage[3].Id);
             }
         }
-    }    
+    }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableIssueTimelineClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableIssueTimelineClientTests.cs
@@ -5,7 +5,7 @@ using Octokit.Reactive;
 using Xunit;
 
 namespace Octokit.Tests.Integration.Reactive
-{    
+{
     public class ObservableIssueTimelineClientTests
     {
         private readonly RepositoryContext _context;
@@ -95,7 +95,7 @@ namespace Octokit.Tests.Integration.Reactive
             var observableTimeline = _client.Issue.Timeline.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
             var timelineEventInfos = await observableTimeline.ToList();
             Assert.Equal(1, timelineEventInfos.Count);
-            Assert.Equal(anotherNewIssue.Id, timelineEventInfos[0].Source.Id);
+            Assert.Equal(anotherNewIssue.Id, timelineEventInfos[0].Source.Issue.Id);
         }
 
         [IntegrationTest]
@@ -152,7 +152,7 @@ namespace Octokit.Tests.Integration.Reactive
             var observableTimeline = _client.Issue.Timeline.GetAllForIssue(_context.Repository.Id, issue.Number);
             var timelineEventInfos = await observableTimeline.ToList();
             Assert.Equal(1, timelineEventInfos.Count);
-            Assert.Equal(anotherNewIssue.Id, timelineEventInfos[0].Source.Id);
+            Assert.Equal(anotherNewIssue.Id, timelineEventInfos[0].Source.Issue.Id);
         }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableIssuesClientTests.cs
@@ -79,7 +79,8 @@ public class ObservableIssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task ReturnsAllIssuesForCurrentUser()
     {
-        var newIssue = new NewIssue("Integration test issue") { Assignee = _context.RepositoryOwner };
+        var newIssue = new NewIssue("Integration test issue");
+        newIssue.Assignees.Add(_context.RepositoryOwner);
         await _client.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
 
         var issues = await _client.GetAllForCurrent().ToList();
@@ -90,7 +91,8 @@ public class ObservableIssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task ReturnsAllIssuesForOwnedAndMemberRepositories()
     {
-        var newIssue = new NewIssue("Integration test issue") { Assignee = _context.RepositoryOwner };
+        var newIssue = new NewIssue("Integration test issue");
+        newIssue.Assignees.Add(_context.RepositoryOwner);
         await _client.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         var result = await _client.GetAllForOwnedAndMemberRepositories().ToList();
 
@@ -108,23 +110,23 @@ public class ObservableIssuesClientTests : IDisposable
         Assert.Equal("Modified integration test issue", updateResult.Title);
     }
 
-     [IntegrationTest]
-     public async Task CanLockAndUnlockIssues()
-     {
-         var newIssue = new NewIssue("Integration Test Issue");
- 
-         var createResult = await _client.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-         Assert.False(createResult.Locked);
- 
-         await _client.Lock(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
-         var lockResult = await _client.Get(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
-         Assert.True(lockResult.Locked);
- 
-         await _client.Unlock(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
-         var unlockIssueResult = await _client.Get(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
-         Assert.False(unlockIssueResult.Locked);
+    [IntegrationTest]
+    public async Task CanLockAndUnlockIssues()
+    {
+        var newIssue = new NewIssue("Integration Test Issue");
+
+        var createResult = await _client.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+        Assert.False(createResult.Locked);
+
+        await _client.Lock(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
+        var lockResult = await _client.Get(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
+        Assert.True(lockResult.Locked);
+
+        await _client.Unlock(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
+        var unlockIssueResult = await _client.Get(_context.RepositoryOwner, _context.RepositoryName, createResult.Number);
+        Assert.False(unlockIssueResult.Locked);
     }
- 
+
     public void Dispose()
     {
         _context.Dispose();

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryCommitsClientTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Integration.Reactive
                 var client = Helper.GetAuthenticatedClient();
                 _repositoryCommitsClient = new ObservableRepositoryCommitsClient(client);
             }
-            
+
             [IntegrationTest]
             public async Task CanGetCorrectCountOfCommitsWithoutStart()
             {

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryPagesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryPagesClientTests.cs
@@ -33,7 +33,7 @@ namespace Octokit.Tests.Integration.Reactive
             {
                 var options = new ApiOptions
                 {
-                    PageSize= 5,
+                    PageSize = 5,
                     PageCount = 1
                 };
 

--- a/Octokit.Tests.Integration/Reactive/ObservableUserKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserKeysClientTests.cs
@@ -65,19 +65,19 @@ namespace Octokit.Tests.Integration.Clients
         [IntegrationTest]
         public async Task CanCreateAndDeleteKey()
         {
-            // Create a key
-            string keyTitle = "title";
-            string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAjo4DqFKg8dOxiz/yjypmN1A4itU5QOStyYrfOFuTinesU/2zm9hqxJ5BctIhgtSHJ5foxkhsiBji0qrUg73Q25BThgNg8YFE8njr4EwjmqSqW13akx/zLV0GFFU0SdJ2F6rBldhi93lMnl0ex9swBqa3eLTY8C+HQGBI6MQUMw+BKp0oFkz87Kv+Pfp6lt/Uo32ejSxML1PT5hTH5n+fyl0ied+sRmPGZWmWoHB5Bc9mox7lB6I6A/ZgjtBqbEEn4HQ2/6vp4ojKfSgA4Mm7XMu0bZzX0itKjH1QWD9Lr5apV1cmZsj49Xf8SHucTtH+bq98hb8OOXEGFzplwsX2MQ==";
+            // Use context helper to create/destroy a key safely (to avoid test failures when a key exists due to not having been deleted)
+            string keyTitle = null;
+            string keyData = null;
+            using (var context = await _github.CreatePublicKeyContext())
+            {
+                var observable = _github.User.GitSshKey.Get(context.KeyId);
+                var key = await observable;
 
-            var observable = _github.User.GitSshKey.Create(new NewPublicKey(keyTitle, keyData));
-            var key = await observable;
+                keyTitle = key.Title;
+                keyData = key.Key;
 
-            Assert.NotNull(key);
-            Assert.Equal(key.Title, "title");
-            Assert.Equal(key.Key, keyData);
-
-            // Delete key
-            await _github.User.GitSshKey.Delete(key.Id);
+                Assert.NotNull(key);
+            }
 
             // Verify key no longer exists
             var keys = await _github.User.GitSshKey.GetAllForCurrent().ToList();

--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -196,6 +196,66 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheAddAssigneesMethod
+        {
+            [Fact]
+            public async Task PostsToCorrectUrl()
+            {
+                var newAssignees = new AssigneesUpdate(new List<string>() { "assignee1", "assignee2" });
+
+                var connection = Substitute.For<IApiConnection>();
+                var client = new AssigneesClient(connection);
+
+                await client.AddAssignees("fake", "repo", 2, newAssignees);
+
+                connection.Received().Post<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/2/assignees"), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new AssigneesClient(Substitute.For<IApiConnection>());
+                var newAssignees = new AssigneesUpdate(new List<string>() { "assignee1", "assignee2" });
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddAssignees("", "name", 2, newAssignees));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddAssignees("owner", "", 2, newAssignees));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddAssignees("owner", "name", 2, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddAssignees(null, "name", 2, newAssignees));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddAssignees("owner", null, 2, newAssignees));
+            }
+        }
+
+        public class TheRemoveAssigneesMethod
+        {
+            [Fact]
+            public async Task PostsToCorrectUrl()
+            {
+                var removeAssignees = new AssigneesUpdate(new List<string>() { "assignee1", "assignee2" });
+
+                var connection = Substitute.For<IApiConnection>();
+                var client = new AssigneesClient(connection);
+
+                await client.RemoveAssignees("fake", "repo", 2, removeAssignees);
+
+                connection.Received().Delete<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/2/assignees"), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new AssigneesClient(Substitute.For<IApiConnection>());
+                var newAssignees = new AssigneesUpdate(new List<string>() { "assignee1", "assignee2" });
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAssignees("", "name", 2, newAssignees));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAssignees("owner", "", 2, newAssignees));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAssignees("owner", "name", 2, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAssignees(null, "name", 2, newAssignees));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAssignees("owner", null, 2, newAssignees));
+            }
+        }
+
         public class TheCtor
         {
             [Fact]

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -70,12 +70,12 @@ namespace Octokit.Tests.Clients
                 connection.Received()
                     .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/sha/statuses"), options);
             }
-            
+
             [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new CommitStatusClient(Substitute.For<IApiConnection>());
-                
+
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", "sha"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, "sha"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null));
@@ -128,7 +128,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNonNullArguments()
             {
                 var client = new CommitStatusClient(Substitute.For<IApiConnection>());
-                
+
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetCombined(null, "name", "sha"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetCombined("owner", null, "sha"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetCombined("owner", "name", null));

--- a/Octokit.Tests/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitsClientTests.cs
@@ -18,7 +18,7 @@ public class CommitsClientTests
 
             await client.Get("owner", "repo", "reference");
 
-            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits/reference"), null, 
+            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits/reference"), null,
                 "application/vnd.github.cryptographer-preview+sha");
         }
 

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -60,7 +60,7 @@ public class DeploymentsClientTests
 
             connection.Received(1)
                 .GetAll<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), null,
-                                    "application/vnd.github.ant-man-preview+json", 
+                                    "application/vnd.github.ant-man-preview+json",
                                     Args.ApiOptions);
         }
 
@@ -74,7 +74,7 @@ public class DeploymentsClientTests
             await client.GetAll(repositoryId);
 
             connection.Received(1)
-                .GetAll<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), 
+                .GetAll<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
                                     Args.ApiOptions);
         }
 
@@ -95,7 +95,7 @@ public class DeploymentsClientTests
             await client.GetAll(owner, name, options);
 
             connection.Received(1)
-                .GetAll<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), 
+                .GetAll<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
                                     null,
                                     "application/vnd.github.ant-man-preview+json",
                                     options);

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -154,7 +154,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllIssuesForRepository("fake", "repo");
 
-                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), Args.ApiOptions);
             }
 
             [Fact]
@@ -165,7 +165,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllIssuesForRepository(1);
 
-                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), Args.ApiOptions);
             }
 
             [Fact]
@@ -183,7 +183,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllIssuesForRepository("fake", "repo", options);
 
-                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), options);
             }
 
             [Fact]
@@ -201,7 +201,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllIssuesForRepository(1, options);
 
-                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), options);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -47,7 +47,7 @@ namespace Octokit.Tests.Clients
                     PageCount = 1,
                     StartPage = 1
                 };
-                
+
                 await client.GetAll(options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "events"), options);
@@ -59,7 +59,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));              
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
             }
         }
 

--- a/Octokit.Tests/Clients/FollowersClientTests.cs
+++ b/Octokit.Tests/Clients/FollowersClientTests.cs
@@ -34,7 +34,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllForCurrent();
 
                 connection.Received().GetAll<User>(
-                    Arg.Is<Uri>(u => u.ToString() == "user/followers"),Args.ApiOptions);
+                    Arg.Is<Uri>(u => u.ToString() == "user/followers"), Args.ApiOptions);
             }
 
             [Fact]
@@ -53,7 +53,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllForCurrent(options);
 
                 connection.Received().GetAll<User>(
-                    Arg.Is<Uri>(u => u.ToString() == "user/followers"),options);
+                    Arg.Is<Uri>(u => u.ToString() == "user/followers"), options);
             }
 
             [Fact]
@@ -61,8 +61,8 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new FollowersClient(connection);
-                                
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(null));                
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(null));
             }
         }
 
@@ -93,7 +93,7 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAll("alfhenrik",options);
+                client.GetAll("alfhenrik", options);
 
                 connection.Received().GetAll<User>(
                     Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/followers"), options);
@@ -107,8 +107,8 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("fake",null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("",ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("fake", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -71,7 +71,6 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist(""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForGist("24", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist("", ApiOptions.None));
-
             }
         }
 

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -74,7 +74,6 @@ public class GistsClientTests
             client.GetAll(options);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), options);
-
         }
 
         [Fact]
@@ -107,7 +106,6 @@ public class GistsClientTests
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
                 DictionaryWithSince, options);
-
         }
 
         [Fact]
@@ -149,7 +147,6 @@ public class GistsClientTests
             client.GetAllPublic(options);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), options);
-
         }
 
         [Fact]
@@ -192,9 +189,7 @@ public class GistsClientTests
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(DateTimeOffset.Now, null));
-
         }
-
     }
 
     public class TheGetAllStarredMethod
@@ -225,7 +220,6 @@ public class GistsClientTests
             client.GetAllStarred(options);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), options);
-
         }
 
         [Fact]
@@ -267,7 +261,6 @@ public class GistsClientTests
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(null));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(DateTimeOffset.Now, null));
-
         }
     }
 
@@ -299,7 +292,6 @@ public class GistsClientTests
             client.GetAllForUser("octokit", options);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), options);
-
         }
 
         [Fact]
@@ -313,7 +305,6 @@ public class GistsClientTests
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
         DictionaryWithSince, Args.ApiOptions);
-
         }
 
         [Fact]
@@ -348,7 +339,6 @@ public class GistsClientTests
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("user", DateTimeOffset.Now, null));
         }
-
     }
 
     public class TheGetAllCommitsMethod
@@ -392,7 +382,6 @@ public class GistsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits("id", null));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits("", ApiOptions.None));
         }
-
     }
 
     public class TheGetAllForksMethod
@@ -553,7 +542,6 @@ public class GistsClientTests
 
             connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1/forks"),
     Arg.Any<object>());
-
         }
     }
 

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -21,7 +21,7 @@ namespace Octokit.Tests.Clients
                 await client.Get("fake", "repo", 42);
 
                 connection.Received().Get<IssueComment>(
-                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"), 
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"),
                     Arg.Any<Dictionary<string, string>>(),
                     "application/vnd.github.squirrel-girl-preview");
             }
@@ -196,7 +196,7 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForIssue("fake", "repo", 3, options);
 
                 connection.Received().GetAll<IssueComment>(
-                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"), 
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"),
                     Arg.Any<Dictionary<string, string>>(),
                     "application/vnd.github.squirrel-girl-preview",
                     options);

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -136,9 +136,11 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", options: null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, options: null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));

--- a/Octokit.Tests/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests/Clients/IssueTimelineClientTests.cs
@@ -29,7 +29,7 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForIssue("fake", "repo", 42);
 
                 connection.Received().GetAll<TimelineEventInfo>(
-                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"), 
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
                     "application/vnd.github.mockingbird-preview",
                     Arg.Any<ApiOptions>());
@@ -41,7 +41,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssueTimelineClient(connection);
 
-                await client.GetAllForIssue("fake", "repo", 42, new ApiOptions {PageSize = 30});
+                await client.GetAllForIssue("fake", "repo", 42, new ApiOptions { PageSize = 30 });
 
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
@@ -71,7 +71,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssueTimelineClient(connection);
 
-                await client.GetAllForIssue(1, 42, new ApiOptions {PageSize = 30});
+                await client.GetAllForIssue(1, 42, new ApiOptions { PageSize = 30 });
 
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
@@ -92,7 +92,6 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "repo", 42));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 42));
-
             }
         }
     }

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -406,8 +406,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("fake", "repo", newIssue);
 
-                connection.Received().Post<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
-                    newIssue);
+                connection.Received().Post<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"), newIssue);
             }
 
             [Fact]
@@ -451,8 +450,7 @@ namespace Octokit.Tests.Clients
 
                 client.Update("fake", "repo", 42, issueUpdate);
 
-                connection.Received().Patch<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42"),
-                    issueUpdate);
+                connection.Received().Patch<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42"), issueUpdate);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
@@ -560,7 +560,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesLabelsClient(connection);
-                
+
                 var labelUpdate = new LabelUpdate("name", "FF0000");
 
                 client.Update("fake", "repo", "labelName", labelUpdate);

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -295,7 +295,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic("org", null));
-                
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllPublic(""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllPublic("", ApiOptions.None));
             }

--- a/Octokit.Tests/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationsClientTests.cs
@@ -81,13 +81,59 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new OrganizationsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll((string)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("username", null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", ApiOptions.None));
             }
+        }
+
+        public class TheGetAllForUserMethod
+        {
+          [Fact]
+          public async Task RequestsTheCorrectUrl()
+          {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new OrganizationsClient(connection);
+
+            await client.GetAllForUser("username");
+
+            connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), Args.ApiOptions);
+          }
+
+          [Fact]
+          public async Task RequestsTheCorrectUrlWithApiOptions()
+          {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new OrganizationsClient(connection);
+
+            var options = new ApiOptions
+            {
+              StartPage = 1,
+              PageCount = 1,
+              PageSize = 1
+            };
+
+            await client.GetAllForUser("username", options);
+
+            connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), options);
+          }
+
+          [Fact]
+          public async Task EnsuresNonNullArguments()
+          {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new OrganizationsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("username", null));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", ApiOptions.None));
+          }
         }
 
         public class TheGetAllForCurrentMethod
@@ -130,7 +176,43 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(null));
             }
         }
+        
+        public class TheGetAllOrganizationsMethod
+        {
+            [Fact]
+            public async Task RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
 
+                await client.GetAll();
+
+                connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "organizations"));
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithRequestParameter()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
+
+                var request =  new OrganizationRequest(1);
+
+                await client.GetAll(request);
+
+                connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "organizations?since=1"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll((OrganizationRequest)null));
+            }
+        }
+        
         public class TheUpdateMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationsClientTests.cs
@@ -92,48 +92,48 @@ namespace Octokit.Tests.Clients
 
         public class TheGetAllForUserMethod
         {
-          [Fact]
-          public async Task RequestsTheCorrectUrl()
-          {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new OrganizationsClient(connection);
-
-            await client.GetAllForUser("username");
-
-            connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), Args.ApiOptions);
-          }
-
-          [Fact]
-          public async Task RequestsTheCorrectUrlWithApiOptions()
-          {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new OrganizationsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public async Task RequestsTheCorrectUrl()
             {
-              StartPage = 1,
-              PageCount = 1,
-              PageSize = 1
-            };
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
 
-            await client.GetAllForUser("username", options);
+                await client.GetAllForUser("username");
 
-            connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), options);
-          }
+                connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), Args.ApiOptions);
+            }
 
-          [Fact]
-          public async Task EnsuresNonNullArguments()
-          {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new OrganizationsClient(connection);
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null, ApiOptions.None));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("username", null));
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", ApiOptions.None));
-          }
+                await client.GetAllForUser("username", options);
+
+                connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("username", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", ApiOptions.None));
+            }
         }
 
         public class TheGetAllForCurrentMethod
@@ -176,7 +176,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(null));
             }
         }
-        
+
         public class TheGetAllOrganizationsMethod
         {
             [Fact]
@@ -196,7 +196,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new OrganizationsClient(connection);
 
-                var request =  new OrganizationRequest(1);
+                var request = new OrganizationRequest(1);
 
                 await client.GetAll(request);
 
@@ -212,7 +212,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll((OrganizationRequest)null));
             }
         }
-        
+
         public class TheUpdateMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -200,7 +200,7 @@ public class PullRequestReviewCommentsClientTests
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"),
-                "application/vnd.github.squirrel-girl-preview", 
+                "application/vnd.github.squirrel-girl-preview",
                 Args.ApiOptions);
         }
 
@@ -254,7 +254,7 @@ public class PullRequestReviewCommentsClientTests
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"),
-                "application/vnd.github.squirrel-girl-preview", 
+                "application/vnd.github.squirrel-girl-preview",
                 options);
         }
 

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -273,7 +273,6 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Edit("", "name", 1, releaseUpdate));
                 await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Edit("owner", "", 1, releaseUpdate));
-                
             }
         }
 
@@ -390,7 +389,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ReleasesClient(Substitute.For<IApiConnection>());
-                
+
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1));
 

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -349,7 +349,7 @@ namespace Octokit.Tests.Clients
                     Arg.Any<Uri>(),
                     Arg.Is<CreateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Branch == "mybranch"));
             }
 
@@ -365,7 +365,63 @@ namespace Octokit.Tests.Clients
                     Arg.Any<Uri>(),
                     Arg.Is<CreateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Branch == "mybranch"));
             }
 
@@ -509,7 +565,7 @@ namespace Octokit.Tests.Clients
                     Arg.Any<Uri>(),
                     Arg.Is<UpdateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Sha == "1234abc"
                         && a.Branch == "mybranch"));
             }
@@ -526,7 +582,65 @@ namespace Octokit.Tests.Clients
                     Arg.Any<Uri>(),
                     Arg.Is<UpdateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithRepositoriesIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Sha == "1234abc"
                         && a.Branch == "mybranch"));
             }

--- a/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
+++ b/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
@@ -28,7 +28,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo");
 
-                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"), 
+                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"),
                     Args.ApiOptions);
             }
 
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1);
 
-                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks"), 
+                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks"),
                     Args.ApiOptions);
             }
 

--- a/Octokit.Tests/Clients/RepositoryInvitationsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryInvitationsClientTests.cs
@@ -107,6 +107,5 @@ public class RepositoryInvitationsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(1, 2, null));
         }
     }
-
 }
 

--- a/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
@@ -317,7 +317,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetSha1("fake", "repo", "ref");
 
-                connection.Received().Get<string>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/ref"), 
+                connection.Received().Get<string>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/ref"),
                     null, "application/vnd.github.chitauri-preview+sha");
             }
 

--- a/Octokit.Tests/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests/Clients/StatisticsClientTests.cs
@@ -64,7 +64,7 @@ namespace Octokit.Tests.Clients
                 var cancellationToken = new CancellationToken(true);
 
                 var connection = Substitute.For<IApiConnection>();
-                
+
                 connection.GetQueuedOperation<Contributor>(expectedEndPoint, cancellationToken)
                     .Returns(Task.FromResult(contributors));
 
@@ -83,7 +83,7 @@ namespace Octokit.Tests.Clients
                 var cancellationToken = new CancellationToken(true);
 
                 var connection = Substitute.For<IApiConnection>();
-                
+
                 connection.GetQueuedOperation<Contributor>(expectedEndPoint, cancellationToken)
                     .Returns(Task.FromResult(contributors));
 
@@ -164,7 +164,7 @@ namespace Octokit.Tests.Clients
                     .Returns(Task.FromResult(response));
 
                 var client = new StatisticsClient(connection);
-                
+
                 var result = await client.GetCommitActivity("owner", "name", cancellationToken);
 
                 Assert.Equal(2, result.Activity[0].Days.Count);
@@ -187,7 +187,7 @@ namespace Octokit.Tests.Clients
                     .Returns(Task.FromResult(response));
 
                 var client = new StatisticsClient(connection);
-                
+
                 var result = await client.GetCommitActivity(1, cancellationToken);
 
                 Assert.Equal(2, result.Activity[0].Days.Count);
@@ -379,7 +379,7 @@ namespace Octokit.Tests.Clients
                 var statisticsClient = new StatisticsClient(client);
 
                 statisticsClient.GetParticipation("owner", "name", cancellationToken);
-                
+
                 client.Received().GetQueuedOperation<Participation>(expectedEndPoint, cancellationToken);
             }
 
@@ -393,7 +393,7 @@ namespace Octokit.Tests.Clients
                 var statisticsClient = new StatisticsClient(client);
 
                 statisticsClient.GetParticipation(1, cancellationToken);
-                
+
                 client.Received().GetQueuedOperation<Participation>(expectedEndPoint, cancellationToken);
             }
 

--- a/Octokit.Tests/Clients/UserGpgKeysClientTests.cs
+++ b/Octokit.Tests/Clients/UserGpgKeysClientTests.cs
@@ -10,7 +10,6 @@ namespace Octokit.Tests.Clients
 {
     public class UserGpgKeysClientTests
     {
-
         public class TheCtor
         {
             [Fact]

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using Octokit.Internal;
+using Xunit;
+
+namespace Octokit.Tests.Exceptions
+{
+    public class AbuseExceptionTests
+    {
+        public class TheConstructor
+        {
+            public class Message
+            {
+                [Fact]
+                public void ContainsAbuseMessageFromApi()
+                {
+                    const string responseBody = "{\"message\":\"You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.\"," +
+                                                "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}";
+
+                    var response = new Response(
+                        HttpStatusCode.Forbidden,
+                        responseBody,
+                        new Dictionary<string, string>(),
+                        "application/json");
+
+                    var abuseException = new AbuseException(response);
+
+                    Assert.Equal("You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.", abuseException.ApiError.Message);
+                }
+
+                [Fact]
+                public void HasDefaultMessage()
+                {
+                    var response = new Response(HttpStatusCode.Forbidden, null, new Dictionary<string, string>(), "application/json");
+                    var abuseException = new AbuseException(response);
+
+                    Assert.Equal("Request Forbidden - Abuse Detection", abuseException.Message);
+                }
+            }
+
+            public class RetryAfterSeconds
+            {
+                public class HappyPath
+                {
+                    [Fact]
+                    public void WithRetryAfterHeader_PopulatesRetryAfterSeconds()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", "30" } };
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.Equal(30, abuseException.RetryAfterSeconds);
+                    }
+
+                    [Fact]
+                    public void WithZeroHeaderValue_RetryAfterSecondsIsZero()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", "0" } };
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.Equal(0, abuseException.RetryAfterSeconds);
+                    }
+                }
+
+                public class UnhappyPaths
+                {
+                    [Fact]
+                    public void NoRetryAfterHeader_RetryAfterSecondsIsSetToTheDefaultOfNull()
+                    {
+                        var headerDictionary = new Dictionary<string, string>();
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.False(abuseException.RetryAfterSeconds.HasValue);
+                    }
+
+                    [Theory]
+                    [InlineData(null)]
+                    [InlineData("")]
+                    [InlineData("    ")]
+                    public void EmptyHeaderValue_RetryAfterSecondsDefaultsToNull(string emptyValueToTry)
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", emptyValueToTry } };
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.False(abuseException.RetryAfterSeconds.HasValue);
+                    }
+
+                    [Fact]
+                    public void NonParseableIntHeaderValue_RetryAfterSecondsDefaultsToNull()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", "ABC" } };
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.False(abuseException.RetryAfterSeconds.HasValue);
+                    }
+
+                    [Fact]
+                    public void NegativeHeaderValue_RetryAfterSecondsDefaultsToNull()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", "-123" } };
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.False(abuseException.RetryAfterSeconds.HasValue);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -23,7 +23,7 @@ namespace Octokit.Tests
 
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, (ICredentialStore)null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore));
-                
+
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, (Uri)null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, baseAddress));
 
@@ -33,7 +33,7 @@ namespace Octokit.Tests
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, null, null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore, null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, null, baseAddress));
-                
+
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore, baseAddress));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, null, baseAddress));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, credentialStore, null));

--- a/Octokit.Tests/Helpers/Arg.cs
+++ b/Octokit.Tests/Helpers/Arg.cs
@@ -51,7 +51,7 @@ namespace Octokit.Tests
         public static Dictionary<string, string> EmptyDictionary
         {
             get { return Arg.Is<Dictionary<string, string>>(d => d.Count == 0); }
-        }               
+        }
 
         public static OrganizationUpdate OrganizationUpdate
         {

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -349,7 +349,7 @@ namespace Octokit.Tests.Http
                 Assert.Equal(45, exception.RetryAfterSeconds);
             }
 
-            [Fact(Skip = "Fails due to https://github.com/octokit/octokit.net/issues/1529. The message is empty but the default message isn't displayed. However, this isn't due to the introduction of AbuseException, but rather something else.")]
+            [Fact]
             public async Task ThrowsAbuseExceptionWithDefaultMessageForUnsafeAbuseResponse()
             {
                 string messageText = string.Empty;

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -271,6 +271,108 @@ namespace Octokit.Tests.Http
 
                 Assert.Equal("YOU SHALL NOT PASS!", exception.Message);
             }
+
+            [Fact]
+            public async Task ThrowsAbuseExceptionForResponseWithAbuseDocumentationLink()
+            {
+                var messageText = "blahblahblah this does not matter because we are testing the URL";
+
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                    "{\"message\":\"" + messageText + "\"," +
+                    "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}",
+                    new Dictionary<string, string>(),
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                await Assert.ThrowsAsync<AbuseException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+            }
+
+            [Fact]
+            public async Task ThrowsAbuseExceptionForResponseWithAbuseDescription()
+            {
+                var messageText = "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.";
+
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                    "{\"message\":\"" + messageText + "\"," +
+                    "\"documentation_url\":\"https://ThisURLDoesNotMatter.com\"}",
+                    new Dictionary<string, string>(),
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                await Assert.ThrowsAsync<AbuseException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+            }
+
+
+            [Fact]
+            public async Task AbuseExceptionContainsTheRetryAfterHeaderAmount()
+            {
+                var messageText = "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.";
+
+                var httpClient = Substitute.For<IHttpClient>();
+                var headerDictionary = new Dictionary<string, string>
+                {
+                    { "Retry-After", "45" }
+                };
+
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                    "{\"message\":\"" + messageText + "\"," +
+                    "\"documentation_url\":\"https://ThisURLDoesNotMatter.com\"}",
+                    headerDictionary,
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var exception = await Assert.ThrowsAsync<AbuseException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+
+                Assert.Equal(45, exception.RetryAfterSeconds);
+            }
+
+            [Fact(Skip = "Fails due to https://github.com/octokit/octokit.net/issues/1529. The message is empty but the default message isn't displayed. However, this isn't due to the introduction of AbuseException, but rather something else.")]
+            public async Task ThrowsAbuseExceptionWithDefaultMessageForUnsafeAbuseResponse()
+            {
+                string messageText = string.Empty;
+
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                     "{\"message\":\"" + messageText + "\"," +
+                    "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}",
+                   new Dictionary<string, string>(),
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var exception = await Assert.ThrowsAsync<AbuseException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+
+                Assert.Equal("Request Forbidden - Abuse Detection", exception.Message);
+            }
         }
 
         public class TheGetHtmlMethod

--- a/Octokit.Tests/Http/RedirectHandlerTests.cs
+++ b/Octokit.Tests/Http/RedirectHandlerTests.cs
@@ -119,7 +119,7 @@ namespace Octokit.Tests.Http
             httpRequestMessage.Content = new StringContent("Hello World");
 
             var response = await adapter.SendAsync(httpRequestMessage, new CancellationToken());
-            
+
             Assert.Equal(response.RequestMessage.Method, httpRequestMessage.Method);
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
         }
@@ -136,7 +136,7 @@ namespace Octokit.Tests.Http
 
             var httpRequestMessage = CreateRequest(HttpMethod.Post);
             httpRequestMessage.Content = new StringContent("Hello World");
-            
+
             var response = await adapter.SendAsync(httpRequestMessage, new CancellationToken());
 
             Assert.Equal(HttpMethod.Get, response.RequestMessage.Method);
@@ -152,7 +152,7 @@ namespace Octokit.Tests.Http
 
             var redirectResponse2 = new HttpResponseMessage(HttpStatusCode.Found);
             redirectResponse2.Headers.Location = new Uri("http://example.org/foo");
-            
+
             var handler = CreateMockHttpHandler(redirectResponse, redirectResponse2);
             var adapter = new HttpClientAdapter(handler);
 

--- a/Octokit.Tests/Models/IssueTest.cs
+++ b/Octokit.Tests/Models/IssueTest.cs
@@ -190,6 +190,27 @@ public class IssueTest
 ""type"": ""User"",
 ""site_admin"": false
 },
+""assignees"": [
+{
+""login"": ""octocat"",
+""id"": 1,
+""avatar_url"": ""https://github.com/images/error/octocat_happy.gif"",
+""gravatar_id"": """",
+""url"": ""https://api.github.com/users/octocat"",
+""html_url"": ""https://github.com/octocat"",
+""followers_url"": ""https://api.github.com/users/octocat/followers"",
+""following_url"": ""https://api.github.com/users/octocat/following{/other_user}"",
+""gists_url"": ""https://api.github.com/users/octocat/gists{/gist_id}"",
+""starred_url"": ""https://api.github.com/users/octocat/starred{/owner}{/repo}"",
+""subscriptions_url"": ""https://api.github.com/users/octocat/subscriptions"",
+""organizations_url"": ""https://api.github.com/users/octocat/orgs"",
+""repos_url"": ""https://api.github.com/users/octocat/repos"",
+""events_url"": ""https://api.github.com/users/octocat/events{/privacy}"",
+""received_events_url"": ""https://api.github.com/users/octocat/received_events"",
+""type"": ""User"",
+""site_admin"": false
+}
+],
 ""milestone"": {
 ""url"": ""https://api.github.com/repos/octocat/Hello-World/milestones/1"",
 ""number"": 1,
@@ -257,9 +278,9 @@ public class IssueTest
 
             var update = issue.ToUpdate();
 
-            Assert.Null(update.Labels);
+            Assert.NotNull(update.Labels);
             Assert.Equal(1, update.Milestone.GetValueOrDefault());
-            Assert.Equal("octocat", update.Assignee);
+            Assert.Equal("octocat", update.Assignees.FirstOrDefault());
         }
     }
 }

--- a/Octokit.Tests/Models/MigrationTests.cs
+++ b/Octokit.Tests/Models/MigrationTests.cs
@@ -113,7 +113,7 @@ namespace Octokit.Tests.Models
         private static readonly Migration migration = new Migration(
             id: 79,
             guid: "0b989ba4-242f-11e5-81e1-c7b6966d2516",
-            state: Migration.MigrationState.Exported, 
+            state: Migration.MigrationState.Exported,
             lockRepositories: true,
             excludeAttachments: false,
             url: "https://api.github.com/orgs/octo-org/migrations/79",
@@ -168,6 +168,5 @@ namespace Octokit.Tests.Models
             Assert.Equal(1, _migrationReuqest.Repositories.Count);
             Assert.Equal(true, _migrationReuqest.LockRepositories);
         }
-
     }
 }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Clients\UserEmailsClientTests.cs" />
     <Compile Include="Clients\WatchedClientTests.cs" />
     <Compile Include="Clients\FollowersClientTests.cs" />
+    <Compile Include="Exceptions\AbuseExceptionTests.cs" />
     <Compile Include="Exceptions\ApiErrorTests.cs" />
     <Compile Include="Exceptions\ApiExceptionTests.cs" />
     <Compile Include="Exceptions\ApiValidationExceptionTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
@@ -64,10 +64,10 @@ namespace Octokit.Tests.Reactive
                     StartPage = 1,
                     PageCount = 1
                 };
-
+                client.GetAllForRepository(owner, name, new ApiOptions { PageSize = 1, StartPage = 1 });
                 client.GetAllForRepository(owner, name, options);
 
-                gitHubClient.Connection.Received(1).Get<List<User>>(_expectedUri,
+                gitHubClient.Connection.Received(2).Get<List<User>>(_expectedUri,
                     Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2), null);
             }
 
@@ -148,6 +148,66 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => client.CheckAssignee(owner, name, string.Empty));
 
                 Assert.Throws<ArgumentException>(() => client.CheckAssignee(1, string.Empty));
+            }
+        }
+
+        public class TheAddAssigneesMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var newAssignees = new AssigneesUpdate(new List<string>() { "assignee1", "assignee2" });
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableAssigneesClient(gitHubClient);
+
+                client.AddAssignees("fake", "repo", 2, newAssignees);
+
+                gitHubClient.Issue.Assignee.Received().AddAssignees("fake", "repo", 2, newAssignees);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableAssigneesClient(githubClient);
+                var newAssignees = new AssigneesUpdate(new List<string>() { "assignee1", "assignee2" });
+
+                Assert.Throws<ArgumentNullException>(() => client.AddAssignees(null, "name", 2, newAssignees));
+                Assert.Throws<ArgumentNullException>(() => client.AddAssignees("name", null, 2, newAssignees));
+                Assert.Throws<ArgumentNullException>(() => client.AddAssignees("owner", "name", 2, null));
+
+                Assert.Throws<ArgumentException>(() => client.AddAssignees("owner", "", 2, newAssignees));
+                Assert.Throws<ArgumentException>(() => client.AddAssignees("", "name", 2, newAssignees));
+            }
+        }
+
+        public class TheRemoveAssigneesMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var newAssignees = new AssigneesUpdate(new List<string>() { "assignee1", "assignee2" });
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableAssigneesClient(gitHubClient);
+
+                client.RemoveAssignees("fake", "repo", 2, newAssignees);
+
+                gitHubClient.Issue.Assignee.Received().RemoveAssignees("fake", "repo", 2, newAssignees);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableAssigneesClient(githubClient);
+                var newAssignees = new AssigneesUpdate(new List<string>() { "assignee1", "assignee2" });
+
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAssignees(null, "name", 2, newAssignees));
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAssignees("owner", null, 2, newAssignees));
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAssignees("owner", "name", 2, null));
+
+                Assert.Throws<ArgumentException>(() => client.RemoveAssignees("owner", "", 2, newAssignees));
+                Assert.Throws<ArgumentException>(() => client.RemoveAssignees("", "name", 2, newAssignees));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableAuthorizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAuthorizationsClientTests.cs
@@ -29,7 +29,7 @@ namespace Octokit.Tests.Reactive
             {
                 var client = Substitute.For<IGitHubClient>();
                 var authEndpoint = new ObservableAuthorizationsClient(client);
-                
+
                 authEndpoint.GetAll(ApiOptions.None);
 
                 client.Connection.Received(1).Get<List<Authorization>>(Arg.Is<Uri>(u => u.ToString() == "authorizations"),

--- a/Octokit.Tests/Reactive/ObservableCommitStatusClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitStatusClientTests.cs
@@ -149,7 +149,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("owner", "repo", "sha", newCommitStatus);
 
-                gitHubClient.Received(). Repository.Status.Create("owner", "repo", "sha", newCommitStatus);
+                gitHubClient.Received().Repository.Status.Create("owner", "repo", "sha", newCommitStatus);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
@@ -60,7 +60,7 @@ namespace Octokit.Tests.Reactive
 
                 _githubClient.Connection.Received(1)
                     .Get<List<Deployment>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), 
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
                         Arg.Any<string>());
             }
 
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Reactive
 
                 _githubClient.Connection.Received(1)
                     .Get<List<Deployment>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), 
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
                         Arg.Any<string>());
             }
 

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -156,7 +156,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository("fake", "repo");
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), 
                     Args.EmptyDictionary, null);
             }
 
@@ -168,7 +168,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository(1);
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/issues/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repositories/1/issues/events", UriKind.Relative), 
                     Args.EmptyDictionary, null);
             }
 
@@ -187,7 +187,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository("fake", "repo", options);
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), 
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
             }
 
@@ -206,7 +206,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository(1, options);
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/issues/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repositories/1/issues/events", UriKind.Relative), 
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
             }
 

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -83,7 +83,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1);
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/events", UriKind.Relative),
                     Args.EmptyDictionary, null);
             }
 
@@ -102,7 +102,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo", options);
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/events", UriKind.Relative),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
             }
 
@@ -121,7 +121,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1, apiOptions);
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/events", UriKind.Relative),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
             }
 
@@ -156,7 +156,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository("fake", "repo");
 
-                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative),
                     Args.EmptyDictionary, null);
             }
 
@@ -168,7 +168,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository(1);
 
-                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repositories/1/issues/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repositories/1/issues/events", UriKind.Relative),
                     Args.EmptyDictionary, null);
             }
 
@@ -187,7 +187,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository("fake", "repo", options);
 
-                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
             }
 
@@ -206,7 +206,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository(1, options);
 
-                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repositories/1/issues/events", UriKind.Relative), 
+                gitHubClient.Connection.Received(1).Get<List<IssueEvent>>(new Uri("repositories/1/issues/events", UriKind.Relative),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
             }
 

--- a/Octokit.Tests/Reactive/ObservableGistsTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGistsTests.cs
@@ -59,7 +59,7 @@ namespace Octokit.Tests.Reactive
                 };
                 client.GetAll(options);
 
-                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"), 
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"),
                                   DictionaryWithApiOptions, null);
             }
 
@@ -99,8 +99,8 @@ namespace Octokit.Tests.Reactive
             {
                 var gitsClient = new ObservableGistsClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAll(null));                
-                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAll(DateTimeOffset.Now, null));                
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAll(null));
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAll(DateTimeOffset.Now, null));
             }
         }
 
@@ -321,8 +321,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => gitsClient.GetAllForUser(""));
                 Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForUser(null, DateTimeOffset.Now));
                 Assert.Throws<ArgumentException>(() => gitsClient.GetAllForUser("", DateTimeOffset.Now));
-                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForUser("samthedev",DateTimeOffset.Now, null));
-                Assert.Throws<ArgumentException>(() => gitsClient.GetAllForUser("",DateTimeOffset.Now, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForUser("samthedev", DateTimeOffset.Now, null));
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllForUser("", DateTimeOffset.Now, ApiOptions.None));
             }
         }
 
@@ -355,7 +355,7 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<GistHistory>>(Arg.Is<Uri>(u => u.ToString() == "gists/id/commits"),
                                   DictionaryWithApiOptions, null);
-            }            
+            }
 
 
             [Fact]
@@ -365,9 +365,8 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllCommits(null));
                 Assert.Throws<ArgumentException>(() => gitsClient.GetAllCommits(""));
-                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllCommits("id", null));                
-                Assert.Throws<ArgumentException>(() => gitsClient.GetAllCommits("", ApiOptions.None));                
-                
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllCommits("id", null));
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllCommits("", ApiOptions.None));
             }
         }
 
@@ -412,7 +411,6 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => gitsClient.GetAllForks(""));
                 Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForks("id", null));
                 Assert.Throws<ArgumentException>(() => gitsClient.GetAllForks("", ApiOptions.None));
-
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -58,7 +58,7 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/comments", UriKind.Relative),
-                    Arg.Any<IDictionary<string, string>>(), 
+                    Arg.Any<IDictionary<string, string>>(),
                     "application/vnd.github.squirrel-girl-preview");
             }
 
@@ -170,7 +170,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForIssue("fake", "repo", 3);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), 
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative),
                     Args.EmptyDictionary,
                     "application/vnd.github.squirrel-girl-preview");
             }

--- a/Octokit.Tests/Reactive/ObservableIssueTimelineClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueTimelineClientTests.cs
@@ -43,8 +43,8 @@ namespace Octokit.Tests.Reactive
                 var timelineEvents = await client.GetAllForIssue("fake", "repo", 42).ToList();
 
                 connection.Received().Get<List<TimelineEventInfo>>(
-                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"), 
-                    Arg.Any<Dictionary<string, string>>(), 
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
+                    Arg.Any<Dictionary<string, string>>(),
                     "application/vnd.github.mockingbird-preview");
                 Assert.Equal(1, timelineEvents.Count);
             }
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Reactive
                 gitHubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 1), "application/vnd.github.mockingbird-preview")
                     .Returns(Task.FromResult(response));
 
-                var timelineEvents = await client.GetAllForIssue("fake", "repo", 42, new ApiOptions {PageSize = 30}).ToList();
+                var timelineEvents = await client.GetAllForIssue("fake", "repo", 42, new ApiOptions { PageSize = 30 }).ToList();
 
                 connection.Received().Get<List<TimelineEventInfo>>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
@@ -116,7 +116,7 @@ namespace Octokit.Tests.Reactive
                 githubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 1), "application/vnd.github.mockingbird-preview")
                     .Returns(Task.FromResult(response));
 
-                var timelineEvents = await client.GetAllForIssue(1, 42, new ApiOptions {PageSize = 30}).ToList();
+                var timelineEvents = await client.GetAllForIssue(1, 42, new ApiOptions { PageSize = 30 }).ToList();
 
                 connection.Received().Get<List<TimelineEventInfo>>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
@@ -137,7 +137,6 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForIssue("", "repo", 42));
                 Assert.Throws<ArgumentException>(() => client.GetAllForIssue("owner", "", 42));
-
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -125,9 +125,9 @@ public class ObservableIssuesClientTests
 
             client.GetAllForRepository("fake", "repo", options);
 
-            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"), 
-                Arg.Is<IDictionary<string, string>>(d => d.Count == 6 
-                && d["filter"] == "assigned" 
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
+                Arg.Is<IDictionary<string, string>>(d => d.Count == 6
+                && d["filter"] == "assigned"
                 && d["state"] == "open"
                 && d["sort"] == "created"
                 && d["direction"] == "desc"
@@ -636,7 +636,6 @@ public class ObservableIssuesClientTests
 
             Assert.Throws<ArgumentException>(() => client.Update("", "name", 42, new IssueUpdate()));
             Assert.Throws<ArgumentException>(() => client.Update("owner", "", 42, new IssueUpdate()));
-            
         }
     }
 

--- a/Octokit.Tests/Reactive/ObservableIssuesEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesEventsClientTests.cs
@@ -77,7 +77,7 @@ namespace Octokit.Tests.Reactive
                 var connection = Substitute.For<IConnection>();
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableIssuesEventsClient(gitHubClient);
-                
+
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -107,7 +107,7 @@ namespace Octokit.Tests.Reactive
                 var connection = Substitute.For<IConnection>();
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableIssuesEventsClient(gitHubClient);
-                
+
                 var options = new ApiOptions
                 {
                     StartPage = 1,

--- a/Octokit.Tests/Reactive/ObservableIssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesLabelsClientTests.cs
@@ -562,9 +562,9 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", newLabel));
                 Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, newLabel));
                 Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
-                
+
                 Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
-                
+
                 Assert.Throws<ArgumentException>(() => client.Create("", "name", newLabel));
                 Assert.Throws<ArgumentException>(() => client.Create("owner", "", newLabel));
             }

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -186,12 +186,12 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
-                
+
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
-                
+
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (MilestoneRequest)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));

--- a/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
@@ -77,7 +77,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableOrganizationsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAll(null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll((string)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("username", null));
 

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -38,7 +38,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll("fake", "repo", 1);
 
-                gitHubClient.Received().PullRequest.Comment.GetAll("fake", "repo", 1);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAll("fake", "repo", 1);
             }
 
             [Fact]
@@ -49,7 +49,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll(1, 1);
 
-                gitHubClient.Received().PullRequest.Comment.GetAll(1, 1);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAll(1, 1);
             }
 
             [Fact]
@@ -67,7 +67,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll("fake", "repo", 1, options);
 
-                gitHubClient.Received().PullRequest.Comment.GetAll("fake", "repo", 1, options);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAll("fake", "repo", 1, options);
             }
 
             [Fact]
@@ -85,7 +85,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll(1, 1, options);
 
-                gitHubClient.Received().PullRequest.Comment.GetAll(1, 1, options);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAll(1, 1, options);
             }
 
             [Fact]
@@ -237,7 +237,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo", request);
 
-                gitHubClient.Received().PullRequest.Comment.GetAllForRepository("fake", "repo", request);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAllForRepository("fake", "repo", request);
             }
 
             [Fact]
@@ -255,7 +255,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1, request);
 
-                gitHubClient.Received().PullRequest.Comment.GetAllForRepository(1, request);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAllForRepository(1, request);
             }
 
             [Fact]
@@ -280,7 +280,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo", request, options);
 
-                gitHubClient.Received().PullRequest.Comment.GetAllForRepository("fake", "repo", request, options);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAllForRepository("fake", "repo", request, options);
             }
 
             [Fact]
@@ -305,7 +305,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1, request, options);
 
-                gitHubClient.Received().PullRequest.Comment.GetAllForRepository(1, request, options);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAllForRepository(1, request, options);
             }
 
             [Fact]
@@ -483,7 +483,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo");
 
-                gitHubClient.Received().PullRequest.Comment.GetAllForRepository("fake", "repo");
+                gitHubClient.Received().PullRequest.ReviewComment.GetAllForRepository("fake", "repo");
             }
 
             [Fact]
@@ -494,7 +494,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1);
 
-                gitHubClient.Received().PullRequest.Comment.GetAllForRepository(1);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAllForRepository(1);
             }
 
             [Fact]
@@ -512,7 +512,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo", options);
 
-                gitHubClient.Received().PullRequest.Comment.GetAllForRepository("fake", "repo", options);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAllForRepository("fake", "repo", options);
             }
 
             [Fact]
@@ -530,7 +530,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1, options);
 
-                gitHubClient.Received().PullRequest.Comment.GetAllForRepository(1, options);
+                gitHubClient.Received().PullRequest.ReviewComment.GetAllForRepository(1, options);
             }
 
             [Fact]
@@ -721,7 +721,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetComment("owner", "name", 53);
 
-                gitHubClient.PullRequest.Comment.Received().GetComment("owner", "name", 53);
+                gitHubClient.PullRequest.ReviewComment.Received().GetComment("owner", "name", 53);
             }
 
             [Fact]
@@ -732,7 +732,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetComment(1, 53);
 
-                gitHubClient.PullRequest.Comment.Received().GetComment(1, 53);
+                gitHubClient.PullRequest.ReviewComment.Received().GetComment(1, 53);
             }
 
             [Fact]
@@ -760,7 +760,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Create("owner", "name", 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().Create("owner", "name", 13, comment);
+                gitHubClient.PullRequest.ReviewComment.Received().Create("owner", "name", 13, comment);
             }
 
             [Fact]
@@ -773,7 +773,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Create(1, 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().Create(1, 13, comment);
+                gitHubClient.PullRequest.ReviewComment.Received().Create(1, 13, comment);
             }
 
             [Fact]
@@ -812,7 +812,7 @@ namespace Octokit.Tests.Reactive
 
                 client.CreateReply("owner", "name", 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().CreateReply("owner", "name", 13, comment);
+                gitHubClient.PullRequest.ReviewComment.Received().CreateReply("owner", "name", 13, comment);
             }
 
             [Fact]
@@ -825,7 +825,7 @@ namespace Octokit.Tests.Reactive
 
                 client.CreateReply(1, 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().CreateReply(1, 13, comment);
+                gitHubClient.PullRequest.ReviewComment.Received().CreateReply(1, 13, comment);
             }
 
             [Fact]
@@ -862,7 +862,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Edit("owner", "name", 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().Edit("owner", "name", 13, comment);
+                gitHubClient.PullRequest.ReviewComment.Received().Edit("owner", "name", 13, comment);
             }
 
             [Fact]
@@ -875,7 +875,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Edit(1, 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().Edit(1, 13, comment);
+                gitHubClient.PullRequest.ReviewComment.Received().Edit(1, 13, comment);
             }
 
             [Fact]
@@ -909,7 +909,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Delete("owner", "name", 13);
 
-                gitHubClient.PullRequest.Comment.Received().Delete("owner", "name", 13);
+                gitHubClient.PullRequest.ReviewComment.Received().Delete("owner", "name", 13);
             }
 
             [Fact]
@@ -920,7 +920,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Delete(1, 13);
 
-                gitHubClient.PullRequest.Comment.Received().Delete(1, 13);
+                gitHubClient.PullRequest.ReviewComment.Received().Delete(1, 13);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -656,7 +656,7 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllLanguages(null, "repo"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllLanguages("owner", null));
-                
+
                 Assert.Throws<ArgumentException>(() => client.GetAllLanguages("", "repo"));
                 Assert.Throws<ArgumentException>(() => client.GetAllLanguages("owner", ""));
             }

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -176,7 +176,7 @@ namespace Octokit.Tests.Reactive
                 githubClient.Connection.Received().Get<List<CommitComment>>(Arg.Is(new Uri("repos/fake/repo/commits/sha/comments", UriKind.Relative)),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2), "application/vnd.github.squirrel-girl-preview");
             }
-            
+
             [Fact]
             public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
             {
@@ -191,7 +191,7 @@ namespace Octokit.Tests.Reactive
                 };
 
                 client.GetAllForCommit(1, "sha", options);
-                githubClient.Connection.Received().Get<List<CommitComment>>(Arg.Is(new Uri("repositories/1/commits/sha/comments", UriKind.Relative)), 
+                githubClient.Connection.Received().Get<List<CommitComment>>(Arg.Is(new Uri("repositories/1/commits/sha/comments", UriKind.Relative)),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2), "application/vnd.github.squirrel-girl-preview");
             }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommitsClientTests.cs
@@ -44,7 +44,6 @@ namespace Octokit.Tests.Reactive
                 Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, request, options).ToTask());
                 Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, options).ToTask());
                 Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", request, null).ToTask());
-
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
@@ -437,7 +437,7 @@ namespace Octokit.Tests.Reactive
                     Arg.Any<Uri>(),
                     Arg.Is<CreateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Branch == "mybranch"));
             }
 
@@ -454,7 +454,66 @@ namespace Octokit.Tests.Reactive
                     Arg.Any<Uri>(),
                     Arg.Is<CreateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Branch == "mybranch"));
+            }
+            [Fact]
+            public void RequestsCorrectUrlWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Branch == "mybranch"));
             }
 
@@ -606,7 +665,7 @@ namespace Octokit.Tests.Reactive
                     Arg.Any<Uri>(),
                     Arg.Is<UpdateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Sha == "1234abc"
                         && a.Branch == "mybranch"));
             }
@@ -624,7 +683,69 @@ namespace Octokit.Tests.Reactive
                     Arg.Any<Uri>(),
                     Arg.Is<UpdateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithRepositoriesIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Sha == "1234abc"
                         && a.Branch == "mybranch"));
             }

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
@@ -59,7 +59,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Equal("<html>README</html>", htmlReadme);
                 apiConnection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme.md"), null);
             }
-            
+
             [Fact]
             public async Task ReturnsReadmeWithRepositoryId()
             {
@@ -781,7 +781,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 client.GetArchive("org", "repo");
-                
+
                 gitHubClient.Received().Repository.Content.GetArchive("org", "repo");
             }
 
@@ -836,7 +836,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 client.GetArchive(1, ArchiveFormat.Zipball, "ref");
-                
+
                 gitHubClient.Received().Repository.Content.GetArchive(1, ArchiveFormat.Zipball, "ref");
             }
 

--- a/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
@@ -265,7 +265,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCurrent(request, options);
 
-                connection.Received().Get<List<Repository>>(endpoint, 
+                connection.Received().Get<List<Repository>>(endpoint,
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 4 && d["direction"] == "asc" && d["per_page"] == "1" && d["page"] == "1"), null);
             }
 
@@ -301,8 +301,8 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCurrentWithTimestamps(options);
 
-                connection.Received().Get<List<RepositoryStar>>(endpoint, 
-                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["per_page"] == "1" && d["page"] == "1"), 
+                connection.Received().Get<List<RepositoryStar>>(endpoint,
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["per_page"] == "1" && d["page"] == "1"),
                     "application/vnd.github.v3.star+json");
             }
 
@@ -343,7 +343,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCurrentWithTimestamps(request, options);
 
-                connection.Received().Get<List<RepositoryStar>>(endpoint, 
+                connection.Received().Get<List<RepositoryStar>>(endpoint,
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 4 && d["direction"] == "asc" && d["per_page"] == "1" && d["page"] == "1"),
                     "application/vnd.github.v3.star+json");
             }
@@ -399,7 +399,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForUser("banana", options);
 
-                connection.Received().Get<List<Repository>>(endpoint, 
+                connection.Received().Get<List<Repository>>(endpoint,
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["per_page"] == "1" && d["page"] == "1"), null);
             }
 
@@ -439,7 +439,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForUser("banana", starredRequest, options);
 
-                connection.Received().Get<List<Repository>>(endpoint, 
+                connection.Received().Get<List<Repository>>(endpoint,
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 4 && d["direction"] == "asc" && d["direction"] == "asc" && d["per_page"] == "1" && d["page"] == "1"),
                     null);
             }
@@ -477,7 +477,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForUserWithTimestamps("banana", options);
 
-                connection.Received().Get<List<RepositoryStar>>(endpoint, 
+                connection.Received().Get<List<RepositoryStar>>(endpoint,
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["per_page"] == "1" && d["page"] == "1"),
                     "application/vnd.github.v3.star+json");
             }

--- a/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
@@ -41,6 +41,6 @@ namespace Octokit.Tests.Reactive
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableTeamsClient(null));
             }
-        } 
+        }
     }
 }

--- a/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
@@ -52,7 +52,7 @@ namespace Octokit.Tests
                 Assert.Throws<ArgumentNullException>(() => client.Get("owner", "name", null));
 
                 Assert.Throws<ArgumentNullException>(() => client.Get(1, null));
-                
+
                 Assert.Throws<ArgumentException>(() => client.Get("", "name", "123456ABCD"));
                 Assert.Throws<ArgumentException>(() => client.Get("owner", "", "123456ABCD"));
                 Assert.Throws<ArgumentException>(() => client.Get("owner", "name", ""));

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -306,7 +306,7 @@ namespace Octokit.Tests
 
                 Assert.Equal(SomeEnum.Unicode, sample.SomeEnum);
             }
-            
+
             [Fact]
             public void RemovesDashFromEnums()
             {
@@ -366,5 +366,4 @@ namespace Octokit.Tests
         SomethingElse,
         Unicode
     }
-
 }

--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -96,6 +96,40 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Add assignees to a specified Issue.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="assignees">List of names of assignees to add</param>
+        /// <returns></returns>
+        public Task<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(assignees, "assignees");
+
+            return ApiConnection.Post<Issue>(ApiUrls.IssueAssignees(owner, name, number), assignees);
+        }
+
+        /// <summary>
+        /// Remove assignees from a specified Issue.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="assignees">List of assignees to remove</param>
+        /// <returns></returns>
+        public Task<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(assignees, "assignees");
+
+            return ApiConnection.Delete<Issue>(ApiUrls.IssueAssignees(owner, name, number), assignees);
+        }
+
+        /// <summary>
         /// Checks to see if a user is an assignee for a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -66,7 +66,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<DeploymentStatus>(ApiUrls.DeploymentStatuses(owner, name, deploymentId), 
+            return ApiConnection.GetAll<DeploymentStatus>(ApiUrls.DeploymentStatuses(owner, name, deploymentId),
                                                           null,
                                                           AcceptHeaders.DeploymentApiPreview,
                                                           options);

--- a/Octokit/Clients/Enterprise/EnterpriseProbe.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseProbe.cs
@@ -44,7 +44,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(productInformation, "productHeader");
             Ensure.ArgumentNotNull(httpClient, "httpClient");
 
-            this.productHeader = productInformation;
+            productHeader = productInformation;
             this.httpClient = httpClient;
         }
 
@@ -93,7 +93,6 @@ namespace Octokit
                 : (IsEnterpriseResponse(response)
                     ? EnterpriseProbeResult.Ok
                     : EnterpriseProbeResult.NotFound);
-
         }
 
         static bool IsEnterpriseResponse(IResponse response)

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -115,7 +115,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name)
+        public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -130,7 +130,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(long repositoryId)
+        public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(long repositoryId)
         {
             return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
         }
@@ -144,13 +144,13 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
+        public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Activity>(ApiUrls.IssuesEvents(owner, name), options);
+            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(owner, name), options);
         }
 
         /// <summary>
@@ -161,11 +161,11 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(long repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Activity>(ApiUrls.IssuesEvents(repositoryId), options);
+            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(repositoryId), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -43,7 +43,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Activity>(ApiUrls.Events(),options);
+            return ApiConnection.GetAll<Activity>(ApiUrls.Events(), options);
         }
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Activity>(ApiUrls.ReceivedEvents(user, true),options);
+            return ApiConnection.GetAll<Activity>(ApiUrls.ReceivedEvents(user, true), options);
         }
 
         /// <summary>
@@ -319,7 +319,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Activity>(ApiUrls.PerformedEvents(user),options);
+            return ApiConnection.GetAll<Activity>(ApiUrls.PerformedEvents(user), options);
         }
 
         /// <summary>
@@ -383,7 +383,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Activity>(ApiUrls.OrganizationEvents(user, organization),options);
+            return ApiConnection.GetAll<Activity>(ApiUrls.OrganizationEvents(user, organization), options);
         }
     }
 }

--- a/Octokit/Clients/FollowersClient.cs
+++ b/Octokit/Clients/FollowersClient.cs
@@ -44,7 +44,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<User>(ApiUrls.Followers(),options);
+            return ApiConnection.GetAll<User>(ApiUrls.Followers(), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/GistCommentsClient.cs
+++ b/Octokit/Clients/GistCommentsClient.cs
@@ -53,7 +53,7 @@ namespace Octokit
         /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
         public Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId, ApiOptions options)
         {
-            Ensure.ArgumentNotNullOrEmptyString(gistId, "gistId");            
+            Ensure.ArgumentNotNullOrEmptyString(gistId, "gistId");
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<GistComment>(ApiUrls.GistComments(gistId), options);

--- a/Octokit/Clients/GistsClient.cs
+++ b/Octokit/Clients/GistsClient.cs
@@ -129,7 +129,6 @@ namespace Octokit
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public Task<IReadOnlyList<Gist>> GetAll(DateTimeOffset since)
         {
-                        
             return GetAll(since, ApiOptions.None);
         }
 
@@ -183,8 +182,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public Task<IReadOnlyList<Gist>> GetAllPublic(DateTimeOffset since)
-        {            
-
+        {
             return GetAllPublic(since, ApiOptions.None);
         }
 
@@ -212,7 +210,6 @@ namespace Octokit
         /// </remarks>
         public Task<IReadOnlyList<Gist>> GetAllStarred()
         {
-
             return GetAllStarred(ApiOptions.None);
         }
 
@@ -238,8 +235,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public Task<IReadOnlyList<Gist>> GetAllStarred(DateTimeOffset since)
-        {            
-
+        {
             return GetAllStarred(since, ApiOptions.None);
         }
 
@@ -300,7 +296,7 @@ namespace Octokit
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
-            
+
             return GetAllForUser(user, since, ApiOptions.None);
         }
 

--- a/Octokit/Clients/IAssigneesClient.cs
+++ b/Octokit/Clients/IAssigneesClient.cs
@@ -48,6 +48,26 @@ namespace Octokit
         Task<bool> CheckAssignee(string owner, string name, string assignee);
 
         /// <summary>
+        /// Add assignees to a specified Issue.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="assignees">List of names of assignees to add</param>
+        /// <returns></returns>
+        Task<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees);
+
+        /// <summary>
+        /// Remove assignees from a specified Issue.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="assignees">List of assignees to remove</param>
+        /// <returns></returns>
+        Task<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees);
+
+        /// <summary>
         /// Checks to see if a user is an assignee for a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Clients/IEventsClient.cs
+++ b/Octokit/Clients/IEventsClient.cs
@@ -78,7 +78,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name);
+        Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(string owner, string name);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -87,7 +87,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(long repositoryId);
+        Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -98,7 +98,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -108,7 +108,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(long repositoryId, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the events for a given repository network

--- a/Octokit/Clients/IEventsClient.cs
+++ b/Octokit/Clients/IEventsClient.cs
@@ -130,7 +130,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name, ApiOptions options);
-        
+
         /// <summary>
         /// Gets all the events for a given organization
         /// </summary>

--- a/Octokit/Clients/IGistsClient.cs
+++ b/Octokit/Clients/IGistsClient.cs
@@ -101,7 +101,7 @@ namespace Octokit
         /// <param name="since">Only gists updated at or after this time are returned</param>
         /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Gist>> GetAllPublic(DateTimeOffset since, ApiOptions options);
-        
+
 
 
         /// <summary>

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
-        
+
         /// <summary>
         /// Get all reactions for a specified Issue Comment
         /// </summary>

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -66,6 +66,42 @@ namespace Octokit
         Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -22,7 +22,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number);
-        
+
         /// <summary>
         /// Gets all  labels for the issue.
         /// </summary>

--- a/Octokit/Clients/IOrganizationsClient.cs
+++ b/Octokit/Clients/IOrganizationsClient.cs
@@ -1,4 +1,5 @@
-﻿#if NET_45
+﻿using System;
+#if NET_45
 using System.Threading.Tasks;
 using System.Collections.Generic;
 #endif
@@ -58,6 +59,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        [Obsolete("Please use IOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
         Task<IReadOnlyList<Organization>> GetAll(string user);
 
         /// <summary>
@@ -67,8 +69,40 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        [Obsolete("Please use IOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
         Task<IReadOnlyList<Organization>> GetAll(string user, ApiOptions options);
 
+        /// <summary>
+        /// Returns all <see cref="Organization" />s for the specified user.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        Task<IReadOnlyList<Organization>> GetAllForUser(string user);
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s for the specified user.
+        /// </summary>
+        /// <param name="user">The login of the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        Task<IReadOnlyList<Organization>> GetAllForUser(string user, ApiOptions options);
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of <see cref="Organization"/>s.</returns>
+        Task<IReadOnlyList<Organization>> GetAll();
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s.
+        /// </summary>
+        /// <param name="request">Search parameters of the last organization seen</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of <see cref="Organization"/>s.</returns>
+        Task<IReadOnlyList<Organization>> GetAll(OrganizationRequest request);
+        
         /// <summary>
         /// Update the specified organization with data from <see cref="OrganizationUpdate"/>.
         /// </summary>

--- a/Octokit/Clients/IOrganizationsClient.cs
+++ b/Octokit/Clients/IOrganizationsClient.cs
@@ -102,7 +102,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of <see cref="Organization"/>s.</returns>
         Task<IReadOnlyList<Organization>> GetAll(OrganizationRequest request);
-        
+
         /// <summary>
         /// Update the specified organization with data from <see cref="OrganizationUpdate"/>.
         /// </summary>

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
-        
+
         /// <summary>
         /// Get all reactions for a specified Pull Request Review Comment.
         /// </summary>

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
@@ -13,9 +14,15 @@ namespace Octokit
     public interface IPullRequestsClient
     {
         /// <summary>
-        /// Client for managing comments.
+        /// Client for managing review comments.
         /// </summary>
+        [Obsolete("Please use IPullRequestsClient.ReviewComment instead. This method will be removed in a future version")]
         IPullRequestReviewCommentsClient Comment { get; }
+
+        /// <summary>
+        /// Client for managing review comments.
+        /// </summary>
+        IPullRequestReviewCommentsClient ReviewComment { get; }
 
         /// <summary>
         /// Get a pull request by number.

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -288,7 +288,7 @@ namespace Octokit
         /// Client for GitHub's Repository Deployments API
         /// </summary>
         /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/deployment/">Collaborators API documentation</a> for more details
+        /// See the <a href="http://developer.github.com/v3/repos/deployments/">Deployments API documentation</a> for more details
         /// </remarks>
         IDeploymentsClient Deployment { get; }
 

--- a/Octokit/Clients/IRepositoryHooksClient.cs
+++ b/Octokit/Clients/IRepositoryHooksClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name);
-        
+
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>

--- a/Octokit/Clients/IStarredClient.cs
+++ b/Octokit/Clients/IStarredClient.cs
@@ -202,14 +202,14 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         Task<bool> CheckStarred(string owner, string name);
-        
+
         /// <summary>
         /// Stars a repository for the authenticated user.
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         Task<bool> StarRepo(string owner, string name);
-        
+
         /// <summary>
         /// Unstars a repository for the authenticated user.
         /// </summary>

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -55,8 +55,8 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return GetAllForRepository(owner, name, ApiOptions.None);
+            
+            return GetAllForRepository(owner, name, new IssueCommentRequest(), ApiOptions.None);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId)
         {
-            return GetAllForRepository(repositoryId, ApiOptions.None);
+            return GetAllForRepository(repositoryId, new IssueCommentRequest(), ApiOptions.None);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForRepository(owner, name, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -95,7 +95,69 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForRepository(repositoryId, new IssueCommentRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -55,7 +55,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            
+
             return GetAllForRepository(owner, name, new IssueCommentRequest(), ApiOptions.None);
         }
 

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -11,7 +11,7 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/issues/timeline/">Issue Timeline API documentation</a> for more information.
     /// </remarks>
-    public class IssueTimelineClient: ApiClient, IIssueTimelineClient
+    public class IssueTimelineClient : ApiClient, IIssueTimelineClient
     {
         public IssueTimelineClient(IApiConnection apiConnection) : base(apiConnection)
         {

--- a/Octokit/Clients/MilestonesClient.cs
+++ b/Octokit/Clients/MilestonesClient.cs
@@ -59,7 +59,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            
+
             return GetAllForRepository(owner, name, new MilestoneRequest());
         }
 

--- a/Octokit/Clients/OrganizationsClient.cs
+++ b/Octokit/Clients/OrganizationsClient.cs
@@ -67,7 +67,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Organization>(ApiUrls.Organizations(), options);
+            return ApiConnection.GetAll<Organization>(ApiUrls.UserOrganizations(), options);
         }
 
         /// <summary>
@@ -76,6 +76,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        [Obsolete("Please use OrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
         public Task<IReadOnlyList<Organization>> GetAll(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -90,12 +91,67 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        [Obsolete("Please use OrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
         public Task<IReadOnlyList<Organization>> GetAll(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Organization>(ApiUrls.Organizations(user), options);
+            return ApiConnection.GetAll<Organization>(ApiUrls.UserOrganizations(user), options);
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s for the specified user.
+        /// </summary>
+        /// <param name="user">The login of the user</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        public Task<IReadOnlyList<Organization>> GetAllForUser(string user)
+        {
+          Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
+          return GetAllForUser(user, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s for the specified user.
+        /// </summary>
+        /// <param name="user">The login of the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        public Task<IReadOnlyList<Organization>> GetAllForUser(string user, ApiOptions options)
+        {
+          Ensure.ArgumentNotNullOrEmptyString(user, "user");
+          Ensure.ArgumentNotNull(options, "options");
+
+          return ApiConnection.GetAll<Organization>(ApiUrls.UserOrganizations(user), options);
+        }
+
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of <see cref="Organization"/>s.</returns>
+        public Task<IReadOnlyList<Organization>> GetAll()
+        {
+          return ApiConnection.GetAll<Organization>(ApiUrls.AllOrganizations());
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s.
+        /// </summary>
+        /// <param name="request">Search parameters of the last organization seen</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of <see cref="Organization"/>s.</returns>
+        public Task<IReadOnlyList<Organization>> GetAll(OrganizationRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            var url = ApiUrls.AllOrganizations(request.Since);
+
+            return ApiConnection.GetAll<Organization>(url);
         }
 
         /// <summary>

--- a/Octokit/Clients/OrganizationsClient.cs
+++ b/Octokit/Clients/OrganizationsClient.cs
@@ -108,9 +108,9 @@ namespace Octokit
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
         public Task<IReadOnlyList<Organization>> GetAllForUser(string user)
         {
-          Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
-          return GetAllForUser(user, ApiOptions.None);
+            return GetAllForUser(user, ApiOptions.None);
         }
 
         /// <summary>
@@ -122,10 +122,10 @@ namespace Octokit
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
         public Task<IReadOnlyList<Organization>> GetAllForUser(string user, ApiOptions options)
         {
-          Ensure.ArgumentNotNullOrEmptyString(user, "user");
-          Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            Ensure.ArgumentNotNull(options, "options");
 
-          return ApiConnection.GetAll<Organization>(ApiUrls.UserOrganizations(user), options);
+            return ApiConnection.GetAll<Organization>(ApiUrls.UserOrganizations(user), options);
         }
 
 
@@ -136,7 +136,7 @@ namespace Octokit
         /// <returns>A list of <see cref="Organization"/>s.</returns>
         public Task<IReadOnlyList<Organization>> GetAll()
         {
-          return ApiConnection.GetAll<Organization>(ApiUrls.AllOrganizations());
+            return ApiConnection.GetAll<Organization>(ApiUrls.AllOrganizations());
         }
 
         /// <summary>

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -14,13 +15,19 @@ namespace Octokit
     {
         public PullRequestsClient(IApiConnection apiConnection) : base(apiConnection)
         {
-            Comment = new PullRequestReviewCommentsClient(apiConnection);
+            ReviewComment = new PullRequestReviewCommentsClient(apiConnection);
         }
 
         /// <summary>
-        /// Client for managing comments.
+        /// Client for managing review comments.
         /// </summary>
-        public IPullRequestReviewCommentsClient Comment { get; private set; }
+        [Obsolete("Please use PullRequestsClient.ReviewComment instead. This method will be removed in a future version")]
+        public IPullRequestReviewCommentsClient Comment { get { return this.ReviewComment; } }
+
+        /// <summary>
+        /// Client for managing review comments.
+        /// </summary>
+        public IPullRequestReviewCommentsClient ReviewComment { get; set; }
 
         /// <summary>
         /// Get a pull request by number.

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -482,7 +482,7 @@ namespace Octokit
         /// Client for GitHub's Repository Deployments API
         /// </summary>
         /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/deployment/">Collaborators API documentation</a> for more details
+        /// See the <a href="https://developer.github.com/v3/repos/deployments/">Deployments API documentation</a> for more details
         /// </remarks>
         public IDeploymentsClient Deployment { get; private set; }
 

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -11,7 +11,7 @@ namespace Octokit
     /// </remarks>
     public class RepositoryCommitsClient : ApiClient, IRepositoryCommitsClient
     {
-        public RepositoryCommitsClient(IApiConnection apiConnection) 
+        public RepositoryCommitsClient(IApiConnection apiConnection)
             : base(apiConnection)
         {
         }

--- a/Octokit/Clients/RepositoryInvitationsClient.cs
+++ b/Octokit/Clients/RepositoryInvitationsClient.cs
@@ -29,7 +29,7 @@ namespace Octokit
                 var httpStatusCode = await Connection.Patch(endpoint, AcceptHeaders.InvitationsApiPreview).ConfigureAwait(false);
                 return httpStatusCode == HttpStatusCode.NoContent;
             }
-            catch(NotFoundException)
+            catch (NotFoundException)
             {
                 return false;
             }
@@ -52,7 +52,7 @@ namespace Octokit
                 var httpStatusCode = await Connection.Delete(endpoint, new object(), AcceptHeaders.InvitationsApiPreview).ConfigureAwait(false);
                 return httpStatusCode == HttpStatusCode.NoContent;
             }
-            catch(NotFoundException)
+            catch (NotFoundException)
             {
                 return false;
             }
@@ -76,7 +76,7 @@ namespace Octokit
                 var httpStatusCode = await Connection.Delete(endpoint, new object(), AcceptHeaders.InvitationsApiPreview).ConfigureAwait(false);
                 return httpStatusCode == HttpStatusCode.NoContent;
             }
-            catch(NotFoundException)
+            catch (NotFoundException)
             {
                 return false;
             }

--- a/Octokit/Clients/UserEmailsClient.cs
+++ b/Octokit/Clients/UserEmailsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         {
             return GetAll(ApiOptions.None);
         }
-        
+
         /// <summary>
         /// Gets all email addresses for the authenticated user.
         /// </summary>

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Runtime.Serialization;
+using System.Security;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Represents a subset of the HTTP 403 - Forbidden response returned from the API when the forbidden response is related to an abuse detection mechanism.
+    /// Containts the amount of seconds after which it's safe to retry the request.
+    /// </summary>
+#if !NETFX_CORE
+    [Serializable]
+#endif
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
+        Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
+    public class AbuseException : ForbiddenException
+    {
+        /// <summary>
+        /// Constructs an instance of AbuseException
+        /// </summary>
+        /// <param name="response">The HTTP payload from the server</param>
+        public AbuseException(IResponse response) : this(response, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance of AbuseException
+        /// </summary>
+        /// <param name="response">The HTTP payload from the server</param>
+        /// <param name="innerException">The inner exception</param>
+        public AbuseException(IResponse response, Exception innerException)
+            : base(response, innerException)
+        {
+            Debug.Assert(response != null && response.StatusCode == HttpStatusCode.Forbidden,
+                "AbuseException created with wrong status code");
+
+            RetryAfterSeconds = ParseRetryAfterSeconds(response);
+        }
+
+        private static int? ParseRetryAfterSeconds(IResponse response)
+        {
+            string secondsValue;
+            if (!response.Headers.TryGetValue("Retry-After", out secondsValue)) { return null; }
+
+            int retrySeconds;
+            if (!int.TryParse(secondsValue, out retrySeconds)) { return null; }
+            if (retrySeconds < 0) { return null; }
+
+            return retrySeconds;
+        }
+
+        public int? RetryAfterSeconds { get; private set; }
+
+        public override string Message
+        {
+            get { return ApiErrorMessageSafe ?? "Request Forbidden - Abuse Detection"; }
+        }
+
+#if !NETFX_CORE
+        /// <summary>
+        /// Constructs an instance of AbuseException
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="SerializationInfo"/> that holds the
+        /// serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="StreamingContext"/> that contains
+        /// contextual information about the source or destination.
+        /// </param>
+        protected AbuseException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        [SecurityCritical]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("RetryAfterSeconds", RetryAfterSeconds);
+        }
+#endif
+    }
+}

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.Serialization;
+using System.Security;
 using Octokit.Internal;
 
 namespace Octokit
@@ -158,6 +159,7 @@ namespace Octokit
             ApiError = (ApiError) info.GetValue("ApiError", typeof(ApiError));
         }
 
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -155,8 +155,8 @@ namespace Octokit
             : base(info, context)
         {
             if (info == null) return;
-            StatusCode = (HttpStatusCode) info.GetInt32("HttpStatusCode");
-            ApiError = (ApiError) info.GetValue("ApiError", typeof(ApiError));
+            StatusCode = (HttpStatusCode)info.GetInt32("HttpStatusCode");
+            ApiError = (ApiError)info.GetValue("ApiError", typeof(ApiError));
         }
 
         [SecurityCritical]

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -178,7 +178,12 @@ namespace Octokit
         {
             get
             {
-                return ApiError != null ? ApiError.Message : null;
+                if (ApiError != null && !string.IsNullOrWhiteSpace(ApiError.Message))
+                {
+                    return ApiError.Message;
+                }
+
+                return null;
             }
         }
 

--- a/Octokit/Exceptions/RateLimitExceededException.cs
+++ b/Octokit/Exceptions/RateLimitExceededException.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Octokit
 {
@@ -94,6 +95,7 @@ namespace Octokit
                          ?? new RateLimit(new Dictionary<string, string>());
         }
 
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Octokit/Exceptions/RepositoryExistsException.cs
+++ b/Octokit/Exceptions/RepositoryExistsException.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Octokit
 {
@@ -117,6 +118,7 @@ namespace Octokit
             ExistingRepositoryWebUrl = (Uri) info.GetValue("ExistingRepositoryWebUrl", typeof(Uri));
         }
 
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Octokit/Exceptions/RepositoryExistsException.cs
+++ b/Octokit/Exceptions/RepositoryExistsException.cs
@@ -115,7 +115,7 @@ namespace Octokit
             RepositoryName = info.GetString("RepositoryName");
             Organization = info.GetString("Organization");
             OwnerIsOrganization = info.GetBoolean("OwnerIsOrganization");
-            ExistingRepositoryWebUrl = (Uri) info.GetValue("ExistingRepositoryWebUrl", typeof(Uri));
+            ExistingRepositoryWebUrl = (Uri)info.GetValue("ExistingRepositoryWebUrl", typeof(Uri));
         }
 
         [SecurityCritical]

--- a/Octokit/Exceptions/RepositoryFormatException.cs
+++ b/Octokit/Exceptions/RepositoryFormatException.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Octokit
 {
@@ -51,6 +52,7 @@ namespace Octokit
             message = info.GetString("Message");
         }
 
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Octokit/Exceptions/RepositoryWebHookConfigException.cs
+++ b/Octokit/Exceptions/RepositoryWebHookConfigException.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Octokit
 {
@@ -48,6 +49,7 @@ namespace Octokit
             message = info.GetString("Message");
         }
 
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Octokit/Exceptions/TwoFactorAuthorizationException.cs
+++ b/Octokit/Exceptions/TwoFactorAuthorizationException.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Octokit
 {
@@ -80,6 +81,7 @@ namespace Octokit
             TwoFactorType = (TwoFactorType) info.GetInt32("TwoFactorType");
         }
 
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Octokit/Exceptions/TwoFactorAuthorizationException.cs
+++ b/Octokit/Exceptions/TwoFactorAuthorizationException.cs
@@ -78,7 +78,7 @@ namespace Octokit
             : base(info, context)
         {
             if (info == null) return;
-            TwoFactorType = (TwoFactorType) info.GetInt32("TwoFactorType");
+            TwoFactorType = (TwoFactorType)info.GetInt32("TwoFactorType");
         }
 
         [SecurityCritical]

--- a/Octokit/Exceptions/TwoFactorChallengeFailedException.cs
+++ b/Octokit/Exceptions/TwoFactorChallengeFailedException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Octokit
 {
@@ -64,7 +65,7 @@ namespace Octokit
             if (info == null) return;
             AuthorizationCode = info.GetString("AuthorizationCode");
         }
-
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -84,7 +84,6 @@ namespace Octokit
             var apiConnection = new ApiConnection(connection);
             Activity = new ActivitiesClient(apiConnection);
             Authorization = new AuthorizationsClient(apiConnection);
-            Deployment = new DeploymentsClient(apiConnection);
             Enterprise = new EnterpriseClient(apiConnection);
             Gist = new GistsClient(apiConnection);
             Git = new GitDatabaseClient(apiConnection);
@@ -246,15 +245,6 @@ namespace Octokit
         /// Refer to the API documentation for more information: https://developer.github.com/v3/search/
         /// </remarks>
         public ISearchClient Search { get; private set; }
-
-        // TODO: this should be under Repositories to align with the API docs
-        /// <summary>
-        /// Access GitHub's Deployments API.
-        /// </summary>
-        /// <remarks>
-        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/deployments/
-        /// </remarks>
-        public IDeploymentsClient Deployment { get; private set; }
 
         /// <summary>
         /// Access GitHub's Enterprise API.

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -75,6 +75,7 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns all of the organizations for the currently logged in user.
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Please use ApiUrls.UserOrganizations() instead. This method will be removed in a future version")]
         public static Uri Organizations()
         {
             return _currentUserOrganizationsUrl;
@@ -85,9 +86,48 @@ namespace Octokit
         /// </summary>
         /// <param name="login">The login for the user</param>
         /// <returns></returns>
+        [Obsolete("Please use ApiUrls.UserOrganizations() instead. This method will be removed in a future version")]
         public static Uri Organizations(string login)
         {
             return "users/{0}/orgs".FormatUri(login);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all of the organizations for the currently logged in user.
+        /// </summary>
+        /// <returns></returns>
+        public static Uri UserOrganizations()
+        {
+            return "user/orgs".FormatUri();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all of the organizations for the specified login.
+        /// </summary>
+        /// <param name="login">The login for the user</param>
+        /// <returns></returns>
+        public static Uri UserOrganizations(string login)
+        {
+            return "users/{0}/orgs".FormatUri(login);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all of the organizations.
+        /// </summary>
+        /// <returns></returns>
+        public static Uri AllOrganizations()
+        {
+          return "organizations".FormatUri();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all of the organizations.
+        /// </summary>
+        /// /// <param name="since">The integer Id of the last Organization that you’ve seen.</param>
+        /// <returns></returns>
+        public static Uri AllOrganizations(long since)
+        {
+          return "organizations?since={0}".FormatUri(since);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -545,6 +545,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> to add and remove assignees for an issue.        
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns></returns>
+        public static Uri IssueAssignees(string owner, string name, int number)
+        {
+            return "repos/{0}/{1}/issues/{2}/assignees".FormatUri(owner, name, number);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the members of the organization
         /// </summary>
         /// <param name="org">The organization</param>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -117,7 +117,7 @@ namespace Octokit
         /// <returns></returns>
         public static Uri AllOrganizations()
         {
-          return "organizations".FormatUri();
+            return "organizations".FormatUri();
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Octokit
         /// <returns></returns>
         public static Uri AllOrganizations(long since)
         {
-          return "organizations?since={0}".FormatUri(since);
+            return "organizations?since={0}".FormatUri(since);
         }
 
         /// <summary>
@@ -2844,8 +2844,6 @@ namespace Octokit
         /// <returns>The <see cref="Uri"/> for comparing two commits.</returns>
         public static Uri RepoCompare(long repositoryId, string @base, string head)
         {
-
-
             Ensure.ArgumentNotNullOrEmptyString(@base, "base");
             Ensure.ArgumentNotNullOrEmptyString(head, "head");
             var encodedBase = @base.UriEncode();

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -496,6 +496,22 @@ namespace Octokit
 
         /// <summary>
         /// Performs an asynchronous HTTP DELETE request.
+        /// </summary>
+        /// <typeparam name="T">The API resource's type.</typeparam>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="data">The object to serialize as the body of the request</param>
+        public async Task<T> Delete<T>(Uri uri, object data)
+        {
+            Ensure.ArgumentNotNull(uri, "uri");
+            Ensure.ArgumentNotNull(data, "data");
+
+            var response = await Connection.Delete<T>(uri, data).ConfigureAwait(false);
+
+            return response.Body;
+        }
+
+        /// <summary>
+        /// Performs an asynchronous HTTP DELETE request.
         /// Attempts to map the response body to an object of type <typeparamref name="T"/>
         /// </summary>
         /// <typeparam name="T">The type to map the response to</typeparam>

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -492,6 +492,20 @@ namespace Octokit
 
         /// <summary>
         /// Performs an asynchronous HTTP DELETE request.
+        /// </summary>
+        /// <typeparam name="T">The API resource's type.</typeparam>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="data">The object to serialize as the body of the request</param>
+        public Task<IApiResponse<T>> Delete<T>(Uri uri, object data)
+        {
+            Ensure.ArgumentNotNull(uri, "uri");
+            Ensure.ArgumentNotNull(data, "data");
+
+            return SendData<T>(uri, HttpMethod.Delete, data, null, null, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Performs an asynchronous HTTP DELETE request.
         /// Attempts to map the response body to an object of type <typeparamref name="T"/>
         /// </summary>
         /// <typeparam name="T">The type to map the response to</typeparam>

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -638,7 +638,7 @@ namespace Octokit
 
             if (body.Contains("abuse-rate-limits") || body.Contains("abuse detection mechanism"))
             {
-                return new AbuseException(response);                
+                return new AbuseException(response);
             }
 
             return new ForbiddenException(response);

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -625,11 +625,23 @@ namespace Octokit
         static Exception GetExceptionForForbidden(IResponse response)
         {
             string body = response.Body as string ?? "";
-            return body.Contains("rate limit exceeded")
-                ? new RateLimitExceededException(response)
-                : body.Contains("number of login attempts exceeded")
-                    ? new LoginAttemptsExceededException(response)
-                    : new ForbiddenException(response);
+
+            if (body.Contains("rate limit exceeded"))
+            {
+                return new RateLimitExceededException(response);
+            }
+
+            if (body.Contains("number of login attempts exceeded"))
+            {
+                return new LoginAttemptsExceededException(response);
+            }
+
+            if (body.Contains("abuse-rate-limits") || body.Contains("abuse detection mechanism"))
+            {
+                return new AbuseException(response);                
+            }
+
+            return new ForbiddenException(response);
         }
 
         internal static TwoFactorType ParseTwoFactorType(IResponse restResponse)

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -322,6 +322,14 @@ namespace Octokit
 
         /// <summary>
         /// Performs an asynchronous HTTP DELETE request.
+        /// </summary>
+        /// <typeparam name="T">The API resource's type.</typeparam>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="data">The object to serialize as the body of the request</param>
+        Task<T> Delete<T>(Uri uri, object data);
+
+        /// <summary>
+        /// Performs an asynchronous HTTP DELETE request.
         /// Attempts to map the response body to an object of type <typeparamref name="T"/>
         /// </summary>
         /// <typeparam name="T">The API resource's type.</typeparam>
@@ -330,7 +338,7 @@ namespace Octokit
         /// <param name="accepts">Specifies accept response media type</param>
         /// <returns>The returned <seealso cref="HttpStatusCode"/></returns>
         Task<T> Delete<T>(Uri uri, object data, string accepts);
-        
+
         /// <summary>
         /// Executes a GET to the API object at the specified URI. This operation is appropriate for API calls which 
         /// queue long running calculations and return a collection of a resource.

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -239,6 +239,14 @@ namespace Octokit
 
         /// <summary>
         /// Performs an asynchronous HTTP DELETE request.
+        /// </summary>
+        /// <typeparam name="T">The API resource's type.</typeparam>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="data">The object to serialize as the body of the request</param>
+        Task<IApiResponse<T>> Delete<T>(Uri uri, object data);
+
+        /// <summary>
+        /// Performs an asynchronous HTTP DELETE request.
         /// Attempts to map the response body to an object of type <typeparamref name="T"/>
         /// </summary>
         /// <typeparam name="T">The type to map the response to</typeparam>

--- a/Octokit/Http/RateLimit.cs
+++ b/Octokit/Http/RateLimit.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Serialization;
+using System.Security;
 using Octokit.Helpers;
 using Octokit.Internal;
 
@@ -82,6 +83,7 @@ namespace Octokit
             ResetAsUtcEpochSeconds = info.GetInt64("ResetAsUtcEpochSeconds");
         }
 
+        [SecurityCritical]
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             Ensure.ArgumentNotNull(info, "info");

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -109,7 +109,6 @@ namespace Octokit.Internal
                                 {
                                     if (attribute.Value.Equals(value))
                                         _cachedEnums[type].Add(attribute.Value, field.GetValue(null));
-
                                 }
                             }
                         }

--- a/Octokit/Models/Request/AssigneesUpdate.cs
+++ b/Octokit/Models/Request/AssigneesUpdate.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Used to add assignees to an issue.
+    /// </summary>
+    /// <remarks>
+    /// API: https://developer.github.com/v3/git/commits/#create-a-commit
+    /// </remarks>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class AssigneesUpdate
+    {
+        public AssigneesUpdate(IReadOnlyList<string> assignees)
+        {
+            Assignees = assignees;
+        }
+
+        public IReadOnlyList<string> Assignees { get; private set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Assignees: {0}", Assignees);
+            }
+        }
+    }
+}

--- a/Octokit/Models/Request/CreateFileRequest.cs
+++ b/Octokit/Models/Request/CreateFileRequest.cs
@@ -107,10 +107,32 @@ namespace Octokit
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="content">The content.</param>
-        public CreateFileRequest(string message, string content) : base(message)
+        public CreateFileRequest(string message, string content) : this(message, content, true)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateFileRequest"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="branch">The branch the request is for.</param>
+        public CreateFileRequest(string message, string content, string branch) : this(message, content, branch, true)
+        { }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="CreateFileRequest" />.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="convertContentToBase64">True to convert content to base64.</param>
+        public CreateFileRequest(string message, string content, bool convertContentToBase64) : base(message)
         {
             Ensure.ArgumentNotNull(content, "content");
 
+            if (convertContentToBase64)
+            {
+                content = content.ToBase64String();
+            }
             Content = content;
         }
 
@@ -120,16 +142,21 @@ namespace Octokit
         /// <param name="message">The message.</param>
         /// <param name="content">The content.</param>
         /// <param name="branch">The branch the request is for.</param>
-        public CreateFileRequest(string message, string content, string branch) : base(message, branch)
+        /// <param name="convertContentToBase64">True to convert content to base64.</param>
+        public CreateFileRequest(string message, string content, string branch, bool convertContentToBase64) : base(message, branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(content, "content");
 
+            if (convertContentToBase64)
+            {
+                content = content.ToBase64String();
+            }
             Content = content;
         }
+
         /// <summary>
-        /// The contents of the file to create. This is required.
+        /// The contents of the file to create, Base64 encoded. This is required.
         /// </summary>
-        [SerializeAsBase64]
         public string Content { get; private set; }
 
         internal virtual string DebuggerDisplay
@@ -154,7 +181,29 @@ namespace Octokit
         /// <param name="content">The content.</param>
         /// <param name="sha">The sha.</param>
         public UpdateFileRequest(string message, string content, string sha)
-            : base(message, content)
+            : this(message, content, sha, true)
+        { }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="UpdateFileRequest" />.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="sha">The sha.</param>
+        /// <param name="branch">The branch the request is for.</param>
+        public UpdateFileRequest(string message, string content, string sha, string branch)
+           : this(message, content, sha, branch, true)
+        { }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="UpdateFileRequest" />.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="sha">The sha.</param>
+        /// <param name="convertContentToBase64">True to convert content to base64.</param>
+        public UpdateFileRequest(string message, string content, string sha, bool convertContentToBase64)
+            : base(message, content, convertContentToBase64)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
@@ -168,8 +217,9 @@ namespace Octokit
         /// <param name="content">The content.</param>
         /// <param name="sha">The sha.</param>
         /// <param name="branch">The branch the request is for.</param>
-        public UpdateFileRequest(string message, string content, string sha, string branch)
-           : base(message, content, branch)
+        /// <param name="convertContentToBase64">True to convert content to base64.</param>
+        public UpdateFileRequest(string message, string content, string sha, string branch, bool convertContentToBase64)
+           : base(message, content, branch, convertContentToBase64)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 

--- a/Octokit/Models/Request/IssueCommentRequest.cs
+++ b/Octokit/Models/Request/IssueCommentRequest.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Used to filter issue comments.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class IssueCommentRequest : RequestParameters
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IssueCommentRequest"/> class.
+        /// </summary>
+        public IssueCommentRequest()
+        {
+            // Default arguments
+            Sort = PullRequestReviewCommentSort.Created;
+            Direction = SortDirection.Ascending;
+            Since = null;
+        }
+
+        /// <summary>
+        /// Can be either created or updated. Default: created.
+        /// </summary>
+        public PullRequestReviewCommentSort Sort { get; set; }
+
+        /// <summary>
+        /// Can be either asc or desc. Default: asc.
+        /// </summary>
+        public SortDirection Direction { get; set; }
+
+        /// <summary>
+        /// Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.
+        /// </summary>
+        public DateTimeOffset? Since { get; set; }
+
+        internal string DebuggerDisplay
+        {
+            get { return string.Format(CultureInfo.InvariantCulture, "Sort: {0}, Direction: {1}, Since: {2}", Sort, Direction, Since); }
+        }
+    }
+}

--- a/Octokit/Models/Request/IssueUpdate.cs
+++ b/Octokit/Models/Request/IssueUpdate.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using Octokit.Internal;
@@ -27,8 +28,16 @@ namespace Octokit
         /// <remarks>
         /// Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise.
         /// </remarks>
-        [SerializeNull]
+        [Obsolete("Please use Assignees property.  This property will no longer be supported by the GitHub API and will be removed in a future version")]
         public string Assignee { get; set; }
+
+        /// <summary>
+        /// List of logins for the multiple users that this issue should be assigned to
+        /// </summary>
+        /// <remarks>
+        /// Only users with push access can set the multiple assignees for new issues.  The assignees are silently dropped otherwise.
+        /// </remarks>
+        public ICollection<string> Assignees { get; private set; }
 
         /// <summary>
         /// Milestone to associate this issue with.
@@ -62,6 +71,54 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Adds the specified assigness to the issue.
+        /// </summary>
+        /// <param name="name">The login of the assignee.</param>
+        public void AddAssignee(string name)
+        {
+            // lazily create the assignees array
+            if (Assignees == null)
+            {
+                Assignees = new List<string>();
+            }
+
+            Assignees.Add(name);
+        }
+
+        /// <summary>
+        /// Clears all the assignees.
+        /// </summary>
+        public void ClearAssignees()
+        {
+            // lazily create the assignees array
+            if (Assignees == null)
+            {
+                Assignees = new List<string>();
+            }
+            else
+            {
+                Assignees.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Removes the specified assignee from the issue
+        /// </summary>
+        /// <param name="name">The login of the assignee to remove</param>
+        public void RemoveAssignee(string name)
+        {
+            // lazily create the assignees array
+            if (Assignees == null)
+            {
+                Assignees = new List<string>();
+            }
+            else
+            {
+                Assignees.Remove(name);
+            }
+        }
+
+        /// <summary>
         /// Adds the specified label to the issue.
         /// </summary>
         /// <param name="name">The name of the label.</param>
@@ -89,6 +146,23 @@ namespace Octokit
             else
             {
                 Labels.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Removes the specified label from the issue
+        /// </summary>
+        /// <param name="name">The name of the label to remove</param>
+        public void RemoveLabel(string name)
+        {
+            // lazily create the label array
+            if (Labels == null)
+            {
+                Labels = new List<string>();
+            }
+            else
+            {
+                Labels.Remove(name);
             }
         }
     }

--- a/Octokit/Models/Request/NewIssue.cs
+++ b/Octokit/Models/Request/NewIssue.cs
@@ -17,6 +17,7 @@ namespace Octokit
         public NewIssue(string title)
         {
             Title = title;
+            Assignees = new Collection<string>();
             Labels = new Collection<string>();
         }
 
@@ -37,6 +38,14 @@ namespace Octokit
         /// Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise.
         /// </remarks>
         public string Assignee { get; set; }
+
+        /// <summary>
+        /// List of logins for the multiple users that this issue should be assigned to
+        /// </summary>
+        /// <remarks>
+        /// Only users with push access can set the multiple assignees for new issues.  The assignees are silently dropped otherwise.
+        /// </remarks>
+        public Collection<string> Assignees { get; private set; }
 
         /// <summary>
         /// Milestone to associate this issue with.

--- a/Octokit/Models/Request/NewIssue.cs
+++ b/Octokit/Models/Request/NewIssue.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -37,6 +38,7 @@ namespace Octokit
         /// <remarks>
         /// Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise.
         /// </remarks>
+        [Obsolete("Please use Assignees property.  This property will no longer be supported by the GitHub API and will be removed in a future version")]
         public string Assignee { get; set; }
 
         /// <summary>

--- a/Octokit/Models/Request/OrganizationRequest.cs
+++ b/Octokit/Models/Request/OrganizationRequest.cs
@@ -1,0 +1,37 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Used as part of the request to retrieve all organizations.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class OrganizationRequest : RequestParameters
+    {
+
+        /// <summary>
+        /// Intializes a new instance of the <see cref="OrganizationRequest"/> class.
+        /// </summary>
+        /// <param name="since">The integer Id of the last Organization that you've seen.</param>
+        public OrganizationRequest(int since)
+        {
+            Ensure.ArgumentNotNull(since, "since");
+          
+            Since = since;
+        }
+      
+        /// <summary>
+        /// Gets or sets the integer Id of the last Organization that you've seen.
+        /// </summary>
+        public long Since { get; set; }
+
+        internal string DebuggerDisplay
+        {
+          get
+          {
+            return string.Format(CultureInfo.InvariantCulture, "Since: {0} ", Since);
+          }
+        }
+    }
+}

--- a/Octokit/Models/Request/OrganizationRequest.cs
+++ b/Octokit/Models/Request/OrganizationRequest.cs
@@ -9,7 +9,6 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class OrganizationRequest : RequestParameters
     {
-
         /// <summary>
         /// Intializes a new instance of the <see cref="OrganizationRequest"/> class.
         /// </summary>
@@ -17,10 +16,10 @@ namespace Octokit
         public OrganizationRequest(int since)
         {
             Ensure.ArgumentNotNull(since, "since");
-          
+
             Since = since;
         }
-      
+
         /// <summary>
         /// Gets or sets the integer Id of the last Organization that you've seen.
         /// </summary>
@@ -28,10 +27,10 @@ namespace Octokit
 
         internal string DebuggerDisplay
         {
-          get
-          {
-            return string.Format(CultureInfo.InvariantCulture, "Since: {0} ", Since);
-          }
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Since: {0} ", Since);
+            }
         }
     }
 }

--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -15,7 +15,6 @@ namespace Octokit
         [Obsolete("Please use the ctor RepositoryUpdate(string name) as Name is a required field")]
         public RepositoryUpdate()
         {
-
         }
 
         /// <summary>
@@ -33,42 +32,42 @@ namespace Octokit
         /// Required. Gets or sets the repository name.
         /// </summary>
         public string Name { get; set; }
-        
+
         /// <summary>
         /// Optional. Gets or sets the repository description. The default is null (do not update)
         /// </summary>
         public string Description { get; set; }
-        
+
         /// <summary>
         /// Optional. Gets or sets the repository homepage url. The default is null (do not update).
         /// </summary>
         public string Homepage { get; set; }
-        
+
         /// <summary>
         /// Gets or sets whether to make the repository private. The default is null (do not update).
         /// </summary>
         public bool? Private { get; set; }
-        
+
         /// <summary>
         /// Gets or sets whether to enable issues for the repository. The default is null (do not update).
         /// </summary>
         public bool? HasIssues { get; set; }
-        
+
         /// <summary>
         /// Optional. Gets or sets whether to enable the wiki for the repository. The default is null (do not update).
         /// </summary>
         public bool? HasWiki { get; set; }
-        
+
         /// <summary>
         /// Optional. Gets or sets whether to enable downloads for the repository. The default is null (do not update).
         /// </summary>
         public bool? HasDownloads { get; set; }
-        
+
         /// <summary>
         /// Optional. Gets or sets the default branch. The default is null (do not update).
         /// </summary>
         public string DefaultBranch { get; set; }
-        
+
         /// <summary>
         /// Optional. Allows the "Rebase and Merge" method to be used.
         /// </summary>

--- a/Octokit/Models/Request/UserUpdate.cs
+++ b/Octokit/Models/Request/UserUpdate.cs
@@ -5,7 +5,7 @@ namespace Octokit
 {
     /// <summary>
     /// Represents updatable fields on a user. Values that are null will not be sent in the request.
-    /// Use string.empty if you want to clear clear a value.
+    /// Use string.empty if you want to clear a value.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class UserUpdate

--- a/Octokit/Models/Response/AccountType.cs
+++ b/Octokit/Models/Response/AccountType.cs
@@ -10,6 +10,11 @@
         /// <summary>
         /// Organization account
         /// </summary>
-        Organization
+        Organization,
+
+        /// <summary>
+        /// Bot account
+        /// </summary>
+        Bot
     }
 }

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -128,7 +128,7 @@ namespace Octokit
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, 
+                return string.Format(CultureInfo.InvariantCulture,
                     "StatusChecks: {0} Restrictions: {1}",
                     RequiredStatusChecks == null ? "disabled" : RequiredStatusChecks.DebuggerDisplay,
                     Restrictions == null ? "disabled" : Restrictions.DebuggerDisplay);
@@ -172,8 +172,8 @@ namespace Octokit
             {
                 return string.Format(CultureInfo.InvariantCulture,
                     "IncludeAdmins: {0} Strict: {1} Contexts: {2}",
-                    IncludeAdmins, 
-                    Strict, 
+                    IncludeAdmins,
+                    Strict,
                     Contexts == null ? "" : String.Join(",", Contexts));
             }
         }
@@ -207,7 +207,7 @@ namespace Octokit
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, 
+                return string.Format(CultureInfo.InvariantCulture,
                     "Teams: {0} Users: {1}",
                     Teams == null ? "" : String.Join(",", Teams),
                     Users == null ? "" : String.Join(",", Users));

--- a/Octokit/Models/Response/CommitContent.cs
+++ b/Octokit/Models/Response/CommitContent.cs
@@ -37,7 +37,7 @@ namespace Octokit
         public string Path { get; protected set; }
 
         /// <summary>
-        /// SHA of the last commit that modified this content.
+        /// SHA of this content.
         /// </summary>
         public string Sha { get; protected set; }
 

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -179,6 +179,26 @@ namespace Octokit
         Committed,
 
         /// <summary>
+        /// The actor requested review from the subject on this pull request.
+        /// </summary>
+        ReviewRequested,
+
+        /// <summary>
+        /// The actor dismissed a review from the pull request.
+        /// </summary>
+        ReviewDismissed,
+
+        /// <summary>
+        /// The actor removed the review request for the subject on this pull request.
+        /// </summary>
+        ReviewRequestRemoved,
+
+        /// <summary>
+        /// Base branch of the pull request was changed.
+        /// </summary>
+        BaseRefChanged,
+
+        /// <summary>
         /// The issue was referenced from another issue.
         /// The source attribute contains the id, actor, and
         /// url of the reference's source.

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -38,7 +38,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// The Id for this issue
+        /// The internal Id for this issue (not the issue number)
         /// </summary>
         public int Id { get; protected set; }
 

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -62,4 +62,17 @@ namespace Octokit
             get { return string.Format(CultureInfo.InvariantCulture, "Id: {0} CreatedAt: {1}", Id, CreatedAt); }
         }
     }
+
+    public enum IssueCommentSort
+    {
+        /// <summary>
+        /// Sort by create date (default)
+        /// </summary>
+        Created,
+
+        /// <summary>
+        /// Sort by the date of the last update
+        /// </summary>
+        Updated
+    }
 }

--- a/Octokit/Models/Response/Milestone.cs
+++ b/Octokit/Models/Response/Milestone.cs
@@ -14,9 +14,10 @@ namespace Octokit
             Number = number;
         }
 
-        public Milestone(Uri url, int number, ItemState state, string title, string description, User creator, int openIssues, int closedIssues, DateTimeOffset createdAt, DateTimeOffset? dueOn, DateTimeOffset? closedAt)
+        public Milestone(Uri url, Uri htmlUrl, int number, ItemState state, string title, string description, User creator, int openIssues, int closedIssues, DateTimeOffset createdAt, DateTimeOffset? dueOn, DateTimeOffset? closedAt)
         {
             Url = url;
+            HtmlUrl = htmlUrl;
             Number = number;
             State = state;
             Title = title;
@@ -33,6 +34,11 @@ namespace Octokit
         /// The URL for this milestone.
         /// </summary>
         public Uri Url { get; protected set; }
+
+        /// <summary>
+        /// The Html page for this milestone.
+        /// </summary>
+        public Uri HtmlUrl { get; protected set; }
 
         /// <summary>
         /// The milestone number.

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -14,7 +15,7 @@ namespace Octokit
             Number = number;
         }
 
-        public PullRequest(Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles, Milestone milestone, bool locked)
+        public PullRequest(Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, IReadOnlyList<User> assignees, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles, Milestone milestone, bool locked)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -34,6 +35,7 @@ namespace Octokit
             Base = @base;
             User = user;
             Assignee = assignee;
+            Assignees = assignees;
             Mergeable = mergeable;
             MergedBy = mergedBy;
             Comments = comments;
@@ -134,6 +136,11 @@ namespace Octokit
         /// The user who is assigned the pull request.
         /// </summary>
         public User Assignee { get; protected set; }
+
+        /// <summary>
+        ///The multiple users this pull request is assigned to.
+        /// </summary>
+        public IReadOnlyList<User> Assignees { get; protected set; }
 
         /// <summary>
         /// The milestone, if any, that this pull request is assigned to.

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -15,8 +15,9 @@ namespace Octokit
             Number = number;
         }
 
-        public PullRequest(Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, IReadOnlyList<User> assignees, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles, Milestone milestone, bool locked)
+        public PullRequest(long id, Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, IReadOnlyList<User> assignees, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles, Milestone milestone, bool locked)
         {
+            Id = id;
             Url = url;
             HtmlUrl = htmlUrl;
             DiffUrl = diffUrl;
@@ -46,6 +47,11 @@ namespace Octokit
             Milestone = milestone;
             Locked = locked;
         }
+
+        /// <summary>
+        /// The internal Id for this pull request (not the pull request number)
+        /// </summary>
+        public long Id { get; protected set; }
 
         /// <summary>
         /// The URL for this pull request.

--- a/Octokit/Models/Response/ReactionSummary.cs
+++ b/Octokit/Models/Response/ReactionSummary.cs
@@ -24,14 +24,14 @@ namespace Octokit
             get
             {
                 return string.Format(
-                    CultureInfo.InvariantCulture, 
-                    "TotalCount: {0} +1: {1} -1: {2} Laugh: {3} Confused: {4} Heart: {5} Hooray: {6}", 
-                    TotalCount, 
-                    Plus1, 
-                    Minus1, 
-                    Laugh, 
-                    Confused, 
-                    Heart, 
+                    CultureInfo.InvariantCulture,
+                    "TotalCount: {0} +1: {1} -1: {2} Laugh: {3} Confused: {4} Heart: {5} Hooray: {6}",
+                    TotalCount,
+                    Plus1,
+                    Minus1,
+                    Laugh,
+                    Confused,
+                    Heart,
                     Hooray);
             }
         }

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -45,6 +45,9 @@ namespace Octokit
             HasIssues = hasIssues;
             HasWiki = hasWiki;
             HasDownloads = hasDownloads;
+            HasPages = hasPages;
+            SubscribersCount = subscribersCount;
+            Size = size;
             AllowRebaseMerge = allowRebaseMerge;
             AllowSquashMerge = allowSquashMerge;
             AllowMergeCommit = allowMergeCommit;
@@ -113,6 +116,12 @@ namespace Octokit
         public bool? AllowSquashMerge { get; protected set; }
 
         public bool? AllowMergeCommit { get; protected set; }
+
+        public bool HasPages { get; protected set; }
+
+        public int SubscribersCount { get; protected set; }
+
+        public long Size { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -110,7 +110,7 @@ namespace Octokit
         public bool HasWiki { get; protected set; }
 
         public bool HasDownloads { get; protected set; }
-        
+
         public bool? AllowRebaseMerge { get; protected set; }
 
         public bool? AllowSquashMerge { get; protected set; }

--- a/Octokit/Models/Response/SourceInfo.cs
+++ b/Octokit/Models/Response/SourceInfo.cs
@@ -8,11 +8,12 @@ namespace Octokit
     {
         public User Actor { get; protected set; }
         public int Id { get; protected set; }
+        public Issue Issue { get; protected set; }
         public string Url { get; protected set; }
 
         internal string DebuggerDisplay
         {
-            get { return string.Format(CultureInfo.InvariantCulture, "Id: {0} Url: {1}", Id, Url); }
+            get { return string.Format(CultureInfo.InvariantCulture, "Id: {0} Url: {1}", Id, Url ?? ""); }
         }
     }
 }

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Models\Request\NewTree.cs" />
     <Compile Include="Models\Request\NewTreeItem.cs" />
     <Compile Include="Models\Request\NewTeam.cs" />
+    <Compile Include="Models\Request\OrganizationRequest.cs" />
     <Compile Include="Models\Request\OrganizationUpdate.cs" />
     <Compile Include="Models\Request\Permission.cs" />
     <Compile Include="Models\Request\ReferenceUpdate.cs" />

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -462,6 +462,7 @@
     <Compile Include="Clients\MigrationsClient.cs" />
     <Compile Include="Models\Request\StartMigrationRequest.cs" />
     <Compile Include="Models\Response\Migration.cs" />
+    <Compile Include="Models\Request\AssigneesUpdate.cs" />
     <Compile Include="Models\Request\NewReaction.cs" />
     <Compile Include="Models\Response\Reaction.cs" />
     <Compile Include="Clients\ReactionsClient.cs" />

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -503,6 +503,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -505,6 +505,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Models\Request\NewTag.cs" />
     <Compile Include="Models\Request\NewTree.cs" />
     <Compile Include="Models\Request\NewTreeItem.cs" />
+    <Compile Include="Models\Request\OrganizationRequest.cs" />
     <Compile Include="Models\Request\PullRequestRequest.cs" />
     <Compile Include="Models\Request\PullRequestUpdate.cs" />
     <Compile Include="Models\Request\RequestParameters.cs" />

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -514,6 +514,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -516,6 +516,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -472,6 +472,7 @@
     <Compile Include="Models\Response\Enterprise\Migration.cs" />
     <Compile Include="Models\Request\StartMigrationRequest.cs" />
     <Compile Include="Models\Response\Migration.cs" />
+    <Compile Include="Models\Request\AssigneesUpdate.cs" />
     <Compile Include="Models\Request\NewReaction.cs" />
     <Compile Include="Models\Response\Reaction.cs" />
     <Compile Include="Clients\ReactionsClient.cs" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Models\Request\NewTag.cs" />
     <Compile Include="Models\Request\NewTree.cs" />
     <Compile Include="Models\Request\NewTreeItem.cs" />
+    <Compile Include="Models\Request\OrganizationRequest.cs" />
     <Compile Include="Models\Response\Feed.cs" />
     <Compile Include="Models\Response\FeedLink.cs" />
     <Compile Include="Models\Request\PullRequestRequest.cs" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -512,6 +512,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -468,6 +468,7 @@
     <Compile Include="Models\Response\Enterprise\Migration.cs" />
     <Compile Include="Models\Request\StartMigrationRequest.cs" />
     <Compile Include="Models\Response\Migration.cs" />
+    <Compile Include="Models\Request\AssigneesUpdate.cs" />
     <Compile Include="Models\Request\NewReaction.cs" />
     <Compile Include="Models\Response\Reaction.cs" />
     <Compile Include="Clients\ReactionsClient.cs" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -510,6 +510,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Models\Request\NewTree.cs" />
     <Compile Include="Models\Request\NewTreeItem.cs" />
     <Compile Include="Models\Request\NewTeam.cs" />
+    <Compile Include="Models\Request\OrganizationRequest.cs" />
     <Compile Include="Models\Request\Permission.cs" />
     <Compile Include="Models\Request\ReferenceUpdate.cs" />
     <Compile Include="Models\Request\PullRequestRequest.cs" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -458,6 +458,7 @@
     <Compile Include="Clients\MigrationsClient.cs" />
     <Compile Include="Models\Request\StartMigrationRequest.cs" />
     <Compile Include="Models\Response\Migration.cs" />
+    <Compile Include="Models\Request\AssigneesUpdate.cs" />
     <Compile Include="Models\Request\NewReaction.cs" />
     <Compile Include="Models\Response\Reaction.cs" />
     <Compile Include="Clients\ReactionsClient.cs" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -502,6 +502,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -500,6 +500,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Models\Request\NewTreeItem.cs" />
     <Compile Include="Models\Request\NewTeam.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />
+    <Compile Include="Models\Request\OrganizationRequest.cs" />
     <Compile Include="Models\Request\OrganizationUpdate.cs" />
     <Compile Include="Models\Request\Permission.cs" />
     <Compile Include="Models\Request\ReferenceUpdate.cs" />

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -507,6 +507,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -509,6 +509,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -466,6 +466,7 @@
     <Compile Include="Clients\MigrationsClient.cs" />
     <Compile Include="Models\Request\StartMigrationRequest.cs" />
     <Compile Include="Models\Response\Migration.cs" />
+    <Compile Include="Models\Request\AssigneesUpdate.cs" />
     <Compile Include="Models\Request\NewReaction.cs" />
     <Compile Include="Clients\ReactionsClient.cs" />
     <Compile Include="Clients\IReactionsClient.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Models\Request\NewPublicKey.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
     <Compile Include="Models\Request\NewUser.cs" />
+    <Compile Include="Models\Request\OrganizationRequest.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
     <Compile Include="Models\Request\RepositoryForksListRequest.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Clients\UserKeysClient.cs" />
     <Compile Include="Clients\RepositoryContentsClient.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Exceptions\LegalRestrictionException.cs" />
     <Compile Include="Exceptions\PrivateRepositoryQuotaExceededException.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Models\Request\ApiOptions.cs" />
     <Compile Include="Models\Request\CollaboratorRequest.cs" />
     <Compile Include="Models\Request\InvitationUpdate.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
     <Compile Include="Models\Request\NewReaction.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Request\NewImpersonationToken.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Models\Request\BranchProtectionUpdate.cs" />
     <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Request\ApiOptions.cs" />
+    <Compile Include="Models\Request\AssigneesUpdate.cs" />
     <Compile Include="Models\Request\CollaboratorRequest.cs" />
     <Compile Include="Models\Request\InvitationUpdate.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ cd Octokit
 ## Contribute
 
 Visit the [Contributor Guidelines](https://github.com/octokit/octokit.net/blob/master/CONTRIBUTING.md)
-for more details.
+for more details. All contributors are expected to follow our
+[Code of Conduct](https://github.com/octokit/octokit.net/blob/master/CODE_OF_CONDUCT.md).
 
 ## Problems?
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,45 @@
+### New in 0.24.0 (released 17/1/2017)
+
+**Features/Enhancements**
+
+ - Add `GetAll` method to `OrganizationsClient` - [#1469](https://github.com/octokit/octokit.net/pull/1469) via [malamour-work](https://github.com/malamour-work)
+ - Add missing fields to `Repository` class - `HasPages`, `SubscribersCount`, `Size` - [#1473](https://github.com/octokit/octokit.net/pull/1473) via [ryangribble](https://github.com/ryangribble)
+ - Allow base64 content for create/update file - [#1488](https://github.com/octokit/octokit.net/pull/1488) via [laedit](https://github.com/laedit)
+ - Add `HtmlUrl` field to `Milestone` class - [#1489](https://github.com/octokit/octokit.net/pull/1489) via [StanleyGoldman](https://github.com/StanleyGoldman)
+ - Add support for passing sort options to `IssueCommentsClient.GetAllForRepository()` - [#1501](https://github.com/octokit/octokit.net/pull/1501) via [pjc0247](https://github.com/pjc0247)
+ - Rename `PullRequest.Comment` to `PullRequest.ReviewComment` for better accuracy - [#1520](https://github.com/octokit/octokit.net/pull/1520) via [bmeverett](https://github.com/bmeverett)
+ - Introduce `AbuseException` - [#1528](https://github.com/octokit/octokit.net/pull/1528) via [SeanKilleen](https://github.com/SeanKilleen)
+ - Add `Id` field to `PullRequest` class - [#1537](https://github.com/octokit/octokit.net/pull/1537) via [YunLi1988](https://github.com/YunLi1988)
+ - Unparseable `ApiErrors` should now fall back to better default error messages - [#1540](https://github.com/octokit/octokit.net/pull/1540) via [SeanKilleen](https://github.com/SeanKilleen)
+
+**Fixes**
+
+ - Fix errors in `ObservableEventsClient` caused by incorrect return types - [#1490](https://github.com/octokit/octokit.net/pull/1490) via [StanleyGoldman](https://github.com/StanleyGoldman)
+ - Add missing `SecurityCritical` attribute on `GetObjectData()` overrides - [#1493](https://github.com/octokit/octokit.net/pull/1493) via [M-Zuber](https://github.com/M-Zuber)
+ - Fix exceptions in Events API by adding missing event types to `EventInfo` enumeration - [#1536](https://github.com/octokit/octokit.net/pull/1536) via [lynnfaraday](https://github.com/lynnfaraday)
+ - Add new AccountType "Bot" to prevent deserialization errors - [#1541](https://github.com/octokit/octokit.net/pull/1541) via [ryangribble](https://github.com/ryangribble)
+
+**Documentation Updates**
+
+ - Clarify `ApiInfo` rate limiting usage in docs - [#1524](https://github.com/octokit/octokit.net/pull/1524) via [SeanKilleen](https://github.com/SeanKilleen)
+ - Clarify label coloring usage in docs - [#1530](https://github.com/octokit/octokit.net/pull/1530) via [SeanKilleen](https://github.com/SeanKilleen)
+
+**Breaking Changes**
+
+ - Creating and Editing Issues (and PullRequests) using `NewIssue` and `IssueUpdate` requests 
+should now use the `Assignees` collection rather than the now deprecated 'Assignee` field. 
+Both fields can't be specified on the same request, so any code still using `Assignee` will 
+need to explicitly set `Assignees` to `null` to avoid Api validation errors.
+
+ - `OrganizationsClient.GetAll(string user)` has been marked obsolete in favour of 
+`OrganizationsClient.GetAllForUser(string user)`
+
+ - `PullRequest.Comment` has been marked obsolete in favour of `PullRequest.ReviewComment`
+
+- Several `EventsClient` methods previously returned the incorrect `Activity` response class. 
+This has been corrected to `IssueEvent` which although is now correct could break calling 
+code that was written assuming this previous incorrect return type.
+
 ### New in 0.23.0 (released 07/10/2016)
 
 **Features**

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -3,12 +3,14 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyProductAttribute("Octokit")]
-[assembly: AssemblyVersionAttribute("0.23.0")]
-[assembly: AssemblyFileVersionAttribute("0.23.0")]
+[assembly: AssemblyVersionAttribute("0.24.0")]
+[assembly: AssemblyFileVersionAttribute("0.24.0")]
 [assembly: ComVisibleAttribute(false)]
-namespace System {
-    internal static class AssemblyVersionInformation {
-        internal const string Version = "0.23.0";
-        internal const string InformationalVersion = "0.23.0";
+namespace System
+{
+    internal static class AssemblyVersionInformation
+    {
+        internal const string Version = "0.24.0";
+        internal const string InformationalVersion = "0.24.0";
     }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,3 +69,27 @@ If you've authenticated as a given user, you can query their details directly:
 ```
 var user = await client.User.Current();
 ```
+
+### Too Much of a Good Thing: Dealing with API Rate Limits
+Like any popular API, Github needs to throttle some requests. The OctoKit.NET client allows you to get some insight into how many requests you have left and when you can start making requests again. It does this via the `ApiInfo` object and the `GetLastApiInfo()` method.
+
+Example usage:
+
+```csharp
+GithubClient client; 
+//Create & initialize the client here
+
+// Prior to first API call, this will be null, because it only deals with the last call.
+var apiInfo = client.GetLastApiInfo();
+
+// If the ApiInfo isn't null, there will be a property called RateLimit
+var rateLimit = apiInfo?.RateLimit;
+
+var howManyRequestsCanIMakePerHour = rateLimit?.Limit;
+var howManyRequestsDoIHaveLeft = rateLimit?.Remaining;
+var whenDoesTheLimitReset = rateLimit?.Reset;
+```
+
+An authenticated client will have a significantly higher limit than an anonymous client. 
+
+For more information on the API and understanding rate limits, you may want to consult [the Github API docs on rate limits](https://developer.github.com/v3/#rate-limiting).

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -14,3 +14,8 @@ The default labels that come with every repository are:
 - invalid
 - question
 - wontfix
+
+## A Note on Label Colors
+The official API returns colors without the leading `#` that you may expect when working with hex colors -- for example, white would return `FFFFFF`, not `#FFFFFF`. 
+
+If you're displaying the colors, you may need to add the `#` in order to display them properly.


### PR DESCRIPTION
Grabbing the latest release and updating things. As of this merge, the only project file that should be changed when updating Octokit is `Octokit-35.csproj`, by copying the file list from `Octokit-mono.csproj`. Should make it easier to track changes this way.

Before merging, this should be tested in GitHub for Unity.